### PR TITLE
add bindings to the ZMQ_ROUTER and ZMQ_DEALER constants

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -753,6 +753,8 @@ static void Initialize(Handle<Object> target) {
     NODE_DEFINE_CONSTANT(target, ZMQ_XREQ);
     NODE_DEFINE_CONSTANT(target, ZMQ_REP);
     NODE_DEFINE_CONSTANT(target, ZMQ_XREP);
+    NODE_DEFINE_CONSTANT(target, ZMQ_DEALER);
+    NODE_DEFINE_CONSTANT(target, ZMQ_ROUTER);
     NODE_DEFINE_CONSTANT(target, ZMQ_PUSH);
     NODE_DEFINE_CONSTANT(target, ZMQ_PULL);
     NODE_DEFINE_CONSTANT(target, ZMQ_PAIR);

--- a/zeromq.js
+++ b/zeromq.js
@@ -9,15 +9,17 @@ var sys = require('sys');
 // A map of convenient names to the ZMQ constants for socket types.
 var namemap = (function() {
   var m = {};
-  m.pub  = m.publish   = m.publisher  = zmq.ZMQ_PUB;
-  m.sub  = m.subscribe = m.subscriber = zmq.ZMQ_SUB;
-  m.req  = m.request   = m.requester  = zmq.ZMQ_REQ;
-  m.xreq = m.xrequest  = m.xrequester = zmq.ZMQ_XREQ;
-  m.rep  = m.reply     = m.replier    = zmq.ZMQ_REP;
-  m.xrep = m.xreply    = m.xreplier   = zmq.ZMQ_XREP;
-  m.push = m.pusher    = zmq.ZMQ_PUSH;
-  m.pull = m.puller    = zmq.ZMQ_PULL;
-  m.pair = zmq.ZMQ_PAIR;
+  m.pub    = m.publish   = m.publisher  = zmq.ZMQ_PUB;
+  m.sub    = m.subscribe = m.subscriber = zmq.ZMQ_SUB;
+  m.req    = m.request   = m.requester  = zmq.ZMQ_REQ;
+  m.xreq   = m.xrequest  = m.xrequester = zmq.ZMQ_XREQ;
+  m.rep    = m.reply     = m.replier    = zmq.ZMQ_REP;
+  m.xrep   = m.xreply    = m.xreplier   = zmq.ZMQ_XREP;
+  m.push   = m.pusher    = zmq.ZMQ_PUSH;
+  m.pull   = m.puller    = zmq.ZMQ_PULL;
+  m.dealer = zmq.ZMQ_DEALER;
+  m.router = zmq.ZMQ_ROUTER;
+  m.pair   = zmq.ZMQ_PAIR;
   return m;
 })();
 


### PR DESCRIPTION
These are available in zeromq 2.1.3+ and are scheduled to replace XREQ/XREP.

https://github.com/zeromq/zeromq2-1/raw/master/NEWS
