### PR TITLE
Fixed issue with missing pkg-config or libzmq still allowing build.

### DIFF
--- a/wscript
+++ b/wscript
@@ -11,7 +11,8 @@ def set_options(opt):
 def configure(conf):
     conf.check_tool("compiler_cxx")
     conf.check_tool("node_addon")
-    conf.check_cfg(package='libzmq', uselib_store='ZMQ', atleast_version='2.1.0', args='--cflags --libs')
+    conf.check_cfg(atleast_pkgconfig_version='0.0.0', mandatory=True, errmsg='pkg-config was not found')
+    conf.check_cfg(package='libzmq', atleast_version='2.1.0', uselib_store='ZMQ', args='--cflags --libs', mandatory=True, errmsg='Package libzmq was not found')
 
 def build(bld):
     obj = bld.new_task_gen("cxx", "shlib", "node_addon")
@@ -19,10 +20,3 @@ def build(bld):
     obj.target = "binding"
     obj.source = "binding.cc"
     obj.uselib = "ZMQ"
-
-def shutdown():
-  # HACK to get binding.node out of build directory.
-  # better way to do this?
-  if exists('./binding.node'): unlink('./binding.node')
-  if Options.commands['build']:
-    link('./build/default/binding.node', './binding.node')

--- a/zmq.js
+++ b/zmq.js
@@ -3,7 +3,7 @@
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 var IOWatcher = process.binding('io_watcher').IOWatcher;
-var zmq = require('./binding');
+var zmq = require('./build/default/binding');
 var sys = require('sys');
 
 // A map of convenient names to the ZMQ constants for socket types.


### PR DESCRIPTION
- Added pkg-config to wscript
- Made pkg-config and libzmq checks mandatory, as to fail configure with non-zero if they are missing.
- removed the shutdown() hack as we can have our javascript file directly reference the built .node file.
