### PR TITLE
Explicit linking with libuuid is required on Cygwin

### DIFF
--- a/wscript
+++ b/wscript
@@ -13,10 +13,11 @@ def configure(conf):
     conf.check_tool("node_addon")
     conf.check_cfg(atleast_pkgconfig_version='0.0.0', mandatory=True, errmsg='pkg-config was not found')
     conf.check_cfg(package='libzmq', atleast_version='2.1.0', uselib_store='ZMQ', args='--cflags --libs', mandatory=True, errmsg='Package libzmq was not found')
+    conf.check(lib='uuid', uselib_store='UUID')
 
 def build(bld):
     obj = bld.new_task_gen("cxx", "shlib", "node_addon")
     obj.cxxflags = ["-Wall", "-Werror"]
     obj.target = "binding"
     obj.source = "binding.cc"
-    obj.uselib = "ZMQ"
+    obj.uselib = "ZMQ UUID"


### PR DESCRIPTION
Without this patch linking fails with unresolved references to _uuid_unparse and other functions from the library.

Also pkg-config doesn't search at `/usr/local/lib/pkgconfig` on Cygwin, so I had to set an environment variable in shell before running node-waf:

``` sh
export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
```

So some more fixing is required to make `npm install zmq` working out of the box on Cygwin
