### PR TITLE
Useful documentation for zmq.send()

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ oh such fun.
 
  * send(message, ...) - `message` is a string to send across the wire. The
    message is not sent immediately, but there is no callback indicating when
-   it has been transmitted. See the [0MQ](http://www.zeromq.org/intro:read-the-manual) documentation for [zmq_send](http://api.zeromq.org/2-1:zmq-send) for exact
+   it has been transmitted. See the
+   [0MQ](http://www.zeromq.org/intro:read-the-manual) documentation for
+   [zmq_send](http://api.zeromq.org/2-1:zmq-send) for exact
    transmission semantics. Raises an exception if the return is < 0.
 
    The message must be a `Buffer` object or a string. It is assumed that


### PR DESCRIPTION
So that someone doesn't have to read the .cc wrapper for the exact semantics again like I just did.
