### PR TITLE
Fixes "../binding.cc:24:16: error: ev.h: No such file or directory"

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -28,7 +28,6 @@
 #include <stdexcept>
 
 #include <v8.h>
-#include <ev.h>
 
 #include <node.h>
 #include <node_buffer.h>


### PR DESCRIPTION
Got this error while installing on a clean install of node v0.6.1, this patch fixes it.

AFAIK node.h includes all that ev.h used to have.

Builds w/o error now and was able to use the build it generated.
