### PR TITLE
Add module methods zmqVersion and zmqVersionInfo

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -761,21 +761,6 @@ namespace zmq {
    */
 
   static Handle<Value>
-  ZmqVersionInfo(const Arguments& args) {
-    HandleScope scope;
-
-    int major, minor, patch;
-    zmq_version(&major, &minor, &patch);
-
-    Local<Array> version = Array::New(3);
-    version->Set(0, Number::New(major));
-    version->Set(1, Number::New(minor));
-    version->Set(2, Number::New(patch));
-
-    return scope.Close(version);
-  }
-
-  static Handle<Value>
   ZmqVersion(const Arguments& args) {
     HandleScope scope;
 
@@ -835,7 +820,6 @@ namespace zmq {
     NODE_DEFINE_CONSTANT(target, STATE_CLOSED);
 
     NODE_SET_METHOD(target, "zmqVersion", ZmqVersion);
-    NODE_SET_METHOD(target, "zmqVersionInfo", ZmqVersionInfo);
 
     Context::Initialize(target);
     Socket::Initialize(target);


### PR DESCRIPTION
These work like pyzmq's zmq_version() and zmq_version_info():
- zmqVersion() returns the ZMQ version string like "2.1.11"
- zmqVersionInfo() returns a list of integers like [2, 1, 11]

Let me know if you want me to change anything like naming or style. (Also sanity check me - I haven't worked with the node api before)
