### PR TITLE
Start using node-gyp to build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ build
 binding.node
 examples/stress-test-client
 node_modules
+Makefile.gyp
+binding.Makefile
+binding.target.gyp.mk
+gyp-mac-tool
+out/

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,0 +1,18 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'binding.cc' ],
+      'libraries': ['-lzmq'],
+      'cflags!': ['-fno-exceptions'],
+      'cflags_cc!': ['-fno-exceptions'],
+      'conditions': [
+        ['OS=="mac"', {
+          'xcode_settings': {
+            'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
+          }
+        }]
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Baby steps. This still needs to move `binding.node` to the right place and modify NPM's `install` target, probably among other things.

``` bash
$ npm install -g node-gyp
$ node-gyp configure --target=0.6
$ node-gyp build
```

Confirmed working on OS X + Ubuntu 11.10 w/ Node 0.6.10.

(`wscript` appears to link to `uuid`, but `binding.cc` doesn't reference it anywhere.)
