### PR TITLE
package: update "engines" field to support node v0.8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dox": "*"
   },
   "engines": {
-    "node": ">=0.3.0 < 0.7.0"
+    "node": ">=0.3.0 <=0.8.x"
   },
   "contributors": [
     "Justin Tulloss <justin.tulloss@gmail.com> (http://justin.harmonize.fm)",


### PR DESCRIPTION
v2.0.3 works for me when I `npm install -f zmq` so this is all that is needed I believe.
