### PR TITLE
uv_poll_* only exists in libuv bundled with node 0.7.9 or newer

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "jade": "*",
     "dox": "*"
   },
+  "engines": {
+    "node": ">=0.7.9"
+  },
   "contributors": [
     "Justin Tulloss <justin.tulloss@gmail.com> (http://justin.harmonize.fm)",
     "Stéphan Kochen <stephan@kochen.nl> (http://stephan.kochen.nl/)",


### PR DESCRIPTION
Let's bring back that stupid engines field! ;-)
