### PR TITLE
Make this link with zmq from Mac Ports on OS X by adding /opt to include & linker path

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -10,7 +10,14 @@
         ['OS=="mac"', {
           'xcode_settings': {
             'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
-          }
+          },
+          # add macports include & lib dirs
+          'include_dirs': [
+            '/opt/local/include',
+          ],
+          'libraries': [
+            '-L/opt/local/lib'
+          ]
         }]
       ]
     }


### PR DESCRIPTION
makes this build under node-gyp on os x w/ zmq from mac ports.
