### PR TITLE
Add zmq requirement information in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-
 # node-zeromq
 
   [ØMQ](http://www.zeromq.org/) bindings for node.js.
 
 ## Installation
+
+Require libzmq 2.1+, not support 3.x yet, https://github.com/zeromq/zeromq2-x
 
     $ npm install zmq
 


### PR DESCRIPTION
Installation fails if use libzmq3, I think we should tell users zmq version requirement in document. 
