### PR TITLE
Added support for pkg-config

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -18,7 +18,15 @@
           'libraries': [
             '-L/opt/local/lib'
           ]
-        }]
+        }],
+        ['OS=="linux"', {
+          'cflags': [
+            '<!(pkg-config libzmq --cflags 2>/dev/null || echo "")',
+          ],
+          'libraries': [
+            '<!(pkg-config libzmq --libs 2>/dev/null || echo "")',
+          ],
+        }],
       ]
     }
   ]


### PR DESCRIPTION
On linux node-gyp will try to use `pkg-config libzmq`, and take its flags, otherwise use default configuration. Related to #132
