### PR TITLE
added; local/remote_lat local/remote_thr perf test

### DIFF
--- a/perf/local_lat.js
+++ b/perf/local_lat.js
@@ -1,0 +1,21 @@
+var zmq = require('../')
+var assert = require('assert')
+
+if (process.argv.length != 5) {
+  console.log('usage: local_lat <bind-to> <message-size> <roundtrip-count>')
+  process.exit(1)
+}
+
+var bind_to = process.argv[2]
+var message_size = Number(process.argv[3])
+var roundtrip_count = Number(process.argv[4])
+var counter = 0
+
+var rep = zmq.socket('rep')
+rep.bindSync(bind_to)
+
+rep.on('message', function (data) {
+  assert.equal(data.length, message_size, 'message-size did not match')
+  rep.send(data)
+  if (++counter === roundtrip_count) rep.close()
+})

--- a/perf/local_thr.js
+++ b/perf/local_thr.js
@@ -1,0 +1,37 @@
+var zmq = require('../')
+var assert = require('assert')
+
+if (process.argv.length != 5) {
+  console.log('usage: local_thr <bind-to> <message-size> <message-count>')
+  process.exit(1)
+}
+
+var bind_to = process.argv[2]
+var message_size = Number(process.argv[3])
+var message_count = Number(process.argv[4])
+var counter = 0
+
+var sub = zmq.socket('sub')
+sub.bindSync(bind_to)
+sub.subscribe('')
+
+var timer = process.hrtime()
+
+sub.on('message', function (data) {
+  assert.equal(data.length, message_size, 'message-size did not match')
+  if (++counter === message_count) finish()
+})
+
+function finish(){
+  var endtime = process.hrtime(timer)
+  var millis = (endtime[0]*1000) + (endtime[1]/1000000)
+  var throughput = message_count / (millis/1000000)
+  var megabits = (throughput * message_size * 8) / 1000000
+
+  console.log('message size: %d [B]', message_size)
+  console.log('message count: %d', message_count)
+  console.log('mean throughput: %d [msg/s]', throughput.toFixed(0))
+  console.log('mean throughput: %d [Mb/s]', megabits.toFixed(0))
+  console.log('overall time: %d secs and %d nanoseconds', endtime[0], endtime[1])
+  sub.close()
+}

--- a/perf/remote_lat.js
+++ b/perf/remote_lat.js
@@ -1,0 +1,44 @@
+var zmq = require('../')
+var assert = require('assert')
+
+if (process.argv.length != 5) {
+  console.log('usage: remote_lat <connect-to> <message-size> <roundtrip-count>')
+  process.exit(1)
+}
+
+var connect_to = process.argv[2]
+var message_size = Number(process.argv[3])
+var roundtrip_count = Number(process.argv[4])
+var message = new Buffer(message_size)
+message.fill('h')
+
+var sendCounter = recvCounter = 0
+
+var req = zmq.socket('req')
+req.connect(connect_to)
+
+var timer = process.hrtime()
+
+req.on('message', function (data) {
+  assert.equal(data.length, message_size, 'message-size did not match')
+  if (++recvCounter === roundtrip_count) finish()
+})
+
+function finish(){
+  var endtime = process.hrtime(timer)
+  var millis = (endtime[0]*1000) + (endtime[1]/1000000)
+
+  console.log('message size: %d [B]', message_size)
+  console.log('roundtrip count: %d', roundtrip_count)
+  console.log('mean latency: %d [msecs]', millis / roundtrip_count * 2)
+  console.log('overall time: %d secs and %d nanoseconds', endtime[0], endtime[1])
+  req.close()
+}
+
+function send(){
+  process.nextTick(function () {
+    req.send(message)
+    if (++sendCounter < roundtrip_count) send()
+  })
+}
+send()

--- a/perf/remote_thr.js
+++ b/perf/remote_thr.js
@@ -1,0 +1,29 @@
+var zmq = require('../')
+var assert = require('assert')
+
+if (process.argv.length != 5) {
+  console.log('usage: remote_thr <bind-to> <message-size> <message-count>')
+  process.exit(1)
+}
+
+var connect_to = process.argv[2]
+var message_size = Number(process.argv[3])
+var message_count = Number(process.argv[4])
+var message = new Buffer(message_size)
+message.fill('h')
+
+console.log(message.length)
+
+var counter = 0
+
+var pub = zmq.socket('pub')
+pub.connect(connect_to)
+
+function send(){
+  process.nextTick(function () {
+    pub.send(message)
+    if (++counter < message_count) send()
+    // else pub.close() // all messages may not be received by local_thr if closed
+  })
+}
+send()


### PR DESCRIPTION
@visionmedia I started implementing the zeromq performance test suite as defined [here](http://www.zeromq.org/results:perf-howto) for the node binding.  Some interesting results thus far.  I will probably continue to implemented inproc and perhaps other perf tests in this branch.

I used the python and lua bindings as a reference:
http://www.zeromq.org/bindings:lua
