### PR TITLE
Add rcvhwm sndhwm to opts, and make sure they are ints not int64

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -393,11 +393,9 @@ namespace zmq {
     // FIXME: How to handle ZMQ_FD on Windows?
     switch (option) {
       case 1:
-      case 23:
-      case 24:
+      case ZMQ_SNDHWM:
+      case ZMQ_RCVHWM:
       case ZMQ_AFFINITY:
-      case ZMQ_SNDBUF:
-      case ZMQ_RCVBUF:
       case ZMQ_RCVMORE:
         return socket->GetSockOpt<uint64_t>(option);
       case 3:
@@ -408,6 +406,8 @@ namespace zmq {
       case ZMQ_IDENTITY:
         return socket->GetSockOpt<char*>(option);
       case ZMQ_EVENTS:
+      case ZMQ_SNDBUF:
+      case ZMQ_RCVBUF:
         return socket->GetSockOpt<uint32_t>(option);
       case ZMQ_FD:
       case ZMQ_TYPE:
@@ -438,8 +438,6 @@ namespace zmq {
 
     switch (option) {
       case 1:
-      case 23:
-      case 24:
       case ZMQ_AFFINITY:
       case ZMQ_SNDBUF:
       case ZMQ_RCVBUF:
@@ -456,6 +454,8 @@ namespace zmq {
       case ZMQ_LINGER:
       case ZMQ_RECONNECT_IVL:
       case ZMQ_BACKLOG:
+      case ZMQ_SNDHWM:
+      case ZMQ_RCVHWM:
         return socket->SetSockOpt<int>(option, args[1]);
       case ZMQ_RCVMORE:
       case ZMQ_EVENTS:

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,9 +53,11 @@ var opts = exports.options = {
   , mcast_loop: zmq.ZMQ_MCAST_LOOP
   , rate: zmq.ZMQ_RATE
   , rcvbuf: zmq.ZMQ_RCVBUF
+  , rcvhwm: zmq.ZMQ_RCVHWM
   , reconnect_ivl: zmq.ZMQ_RECONNECT_IVL
   , recovery_ivl: zmq.ZMQ_RECOVERY_IVL
   , sndbuf: zmq.ZMQ_SNDBUF
+  , sndhwm: zmq.ZMQ_SNDHWM
   , swap: zmq.ZMQ_SWAP
 };
 


### PR DESCRIPTION
- Add to opts dictionary to allow send and receive highwatermarks to be read and set using socket.sndhwm and socket.rcvhwm
- Use Int32 for snd, rcv hwm
