### PR TITLE
fixed hanging testcases on fast Linux machines

### DIFF
--- a/test/test.socket.pub-sub.filter.js
+++ b/test/test.socket.pub-sub.filter.js
@@ -26,8 +26,20 @@ sub.on('message', function(msg){
 
 sub.bind('inproc://stuff', function(){
   pub.connect('inproc://stuff');
-  pub.send('js is cool');
-  pub.send('ruby is meh');
-  pub.send('py is pretty cool');
-  pub.send('luna is cool too');
+
+  // The connect is asynchronous, and messages published to a non-
+  // connected socket are silently dropped.  That means that there is
+  // a race between connecting and sending the first message which
+  // causes this test to hang, especially when running on Linux. Even an
+  // inproc:// socket seems to be asynchronous.  So instead of
+  // sending straight away, we wait 100ms for the connection to be
+  // established before we start the send.  This fixes the observed
+  // hang.
+
+  setTimeout(function() {
+    pub.send('js is cool');
+    pub.send('ruby is meh');
+    pub.send('py is pretty cool');
+    pub.send('luna is cool too');
+  }, 100.0);
 });

--- a/test/test.socket.pub-sub.js
+++ b/test/test.socket.pub-sub.js
@@ -25,9 +25,23 @@ sub.on('message', function(msg){
   }
 });
 
-sub.bind('inproc://stuff', function(){
-  pub.connect('inproc://stuff');
-  pub.send('foo');
-  pub.send('bar');
-  pub.send('baz');
+var addr = "inproc://stuff";
+
+sub.bind(addr, function(){
+  pub.connect(addr);
+
+  // The connect is asynchronous, and messages published to a non-
+  // connected socket are silently dropped.  That means that there is
+  // a race between connecting and sending the first message which
+  // causes this test to hang, especially when running on Linux. Even an
+  // inproc:// socket seems to be asynchronous.  So instead of
+  // sending straight away, we wait 100ms for the connection to be
+  // established before we start the send.  This fixes the observed
+  // hang.
+
+  setTimeout(function() {
+    pub.send('foo');
+    pub.send('bar');
+    pub.send('baz');
+  }, 100.0);
 });


### PR DESCRIPTION
This patch fixes the hanging test.socket.pub-sub*.js testcases.

They hang on my fast Linux box.  It's due to a race between connect() (which executes asynchronously and gives no way to know when it's completed in zmq 2.x) and the publishing of the messages:

No race:

connect() [ in progress ]
connect() [ finished ]
send()  [ works as something is listening]

Race:

connect() [ in progress ]
send()  [ dropped as nothing is listening ]
connect() [ finished ]

The fix adds a 100ms delay between the connect() and the send() to make sure that the connect is able to complete and so that the send()ed message isn't dropped.  Note that the race occurs even with a inproc:// connection.
