### PR TITLE
Type may now be either a String or a Number.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -99,7 +99,8 @@ function gcWrap (self) {}
 
 function Socket(type) {
   this.type = type;
-  this._zmq = new zmq.Socket(defaultContext(), types[type]);
+  this._type = typeof type === 'number' ? type : types[type];
+  this._zmq = new zmq.Socket(defaultContext(), this._type);
   this._zmq.onReady = this._flush.bind(this);
   this._outgoing = [];
   this._shouldFlush = true;

--- a/test/test.socket.js
+++ b/test/test.socket.js
@@ -11,6 +11,11 @@ zmq.createSocket.should.equal(zmq.socket);
 var sock = zmq.socket('req');
 sock.type.should.equal('req');
 sock.close.should.be.a('function');
+sock.close();
+
+sock = zmq.socket(zmq.ZMQ_REQ);
+sock.type.should.equal(zmq.ZMQ_REQ);
+sock.close.should.be.a('function');
 
 // setsockopt
 


### PR DESCRIPTION
This is what the docstring for the Socket constructor claims, and is now correct.

Side Effect:
There is now a `_type` property on all returned Socket objects. `_type` is always a Number, corresponding directly to the ZMQ enum.

I could have opted to use the existing `type` property this way, but that seems of minor importance, and I decided compatibility with existing expectations was most important. If that should be changed, let me know.
