### PR TITLE
Fix semver usage

### DIFF
--- a/test/test.exports.js
+++ b/test/test.exports.js
@@ -54,7 +54,7 @@ if (semver.satisfies(zmq.version, '2.x')) {
 }
 
 // 3.0 and above.
-if (semver.gte(zmq.version, '3.0')) {
+if (semver.gte(zmq.version, '3.0.0')) {
   constants.concat([
     'XPUB',
     'XSUB',
@@ -64,7 +64,7 @@ if (semver.gte(zmq.version, '3.0')) {
 }
 
 // 3.2 and above.
-if (semver.gte(zmq.version, '3.2')) {
+if (semver.gte(zmq.version, '3.2.0')) {
   constants.concat([
     'LAST_ENDPOINT'
   ]);


### PR DESCRIPTION
1) Don't use `semver.satisfies(..., 3.x)` fail where constants will likely exist in future libzmq version 4.
2) Added missing argument in `semver.gte()` that had been leading to test always ignore related constants.
