### PR TITLE
Benchmark fix

### DIFF
--- a/perf/local_thr.js
+++ b/perf/local_thr.js
@@ -31,7 +31,7 @@ function finish(){
   console.log('message size: %d [B]', message_size)
   console.log('message count: %d', message_count)
   console.log('mean throughput: %d [msg/s]', throughput.toFixed(0))
-  console.log('mean throughput: %d [Mb/s]', megabits.toFixed(0))
+  console.log('mean throughput: %d [Mbit/s]', megabits.toFixed(0))
   console.log('overall time: %d secs and %d nanoseconds', endtime[0], endtime[1])
   sub.close()
 }


### PR DESCRIPTION
1) Benchmark without this fix shows 1000 times better performance than actual.
2) It's better to use wording of monosemantic Mbit instead of Mb.
