### PR TITLE
Add support for Joyent SmartMachines

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -32,7 +32,7 @@
           'cflags!': ['-fno-exceptions'],
           'cflags_cc!': ['-fno-exceptions'],
         }],
-        ['OS=="mac"', {
+        ['OS=="mac" or OS=="solaris"', {
           'xcode_settings': {
             'GCC_ENABLE_CPP_EXCEPTIONS': 'YES'
           },


### PR DESCRIPTION
Joyent machines use same locations as Homebrew so simply using the same rules as with MacOS is fine and works.
