### PR TITLE
Put back the setImmediate

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -151,7 +151,7 @@ function Socket(type) {
   EventEmitter.call(this);
   this.type = type;
   this._zmq = new zmq.Socket(defaultContext(), types[type]);
-  this._zmq.onReady = this._flush.bind(this);
+  this._zmq.onReady = setImmediate.bind(null, this._flush.bind(this));
   this._outgoing = [];
   this._shouldFlush = true;
 };


### PR DESCRIPTION
Actually when testing software using the latest zmq IPC with node 0.10.x, it started crashing throwing me some "Socket is busy" exceptions.
Putting back the `setImmediate` call fixed the issue.
