### PR TITLE
fixed zmq version check for xpub/xsub sockets.

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -988,7 +988,7 @@ namespace zmq {
     NODE_DEFINE_CONSTANT(target, ZMQ_CAN_DISCONNECT);
     NODE_DEFINE_CONSTANT(target, ZMQ_PUB);
     NODE_DEFINE_CONSTANT(target, ZMQ_SUB);
-    #if ZMQ_VERSION_MAJOR == 3
+    #if ZMQ_VERSION_MAJOR >= 3
     NODE_DEFINE_CONSTANT(target, ZMQ_XPUB);
     NODE_DEFINE_CONSTANT(target, ZMQ_XSUB);
     #endif


### PR DESCRIPTION
The xsub and xpub socket fail with zeromq version 4.0.1 because of an improper version check in the bindings.
