### PR TITLE
handle received message immediately for receive only sockets to prevent memory leak in driver

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -333,7 +333,6 @@ Socket.prototype._flush = function() {
   // exhaustion and write starvation
   if (this._flushing) return;
 
-
   if(zmq.STATE_CLOSED == this._zmq.state) return;
 
   this._flushing = true;
@@ -352,12 +351,17 @@ Socket.prototype._flush = function() {
             emitArgs.push(this._zmq.recv());
           } while (this._receiveMore);
 
-          // Allows flush to complete before handling received messages.
-          (function(emitArgs) {
-            setImmediate(function(){
-              self.emit.apply(self, emitArgs);
-            });
-          })(emitArgs);
+          // Handle received message immediately for receive only sockets to prevent memory leak in driver
+          if (types[this.type] === zmq.ZMQ_SUB || types[this.type] === zmq.ZMQ_PULL) {
+            self.emit.apply(self, emitArgs);
+          } else {
+            // Allows flush to complete before handling received messages.
+            (function(emitArgs) {
+              setImmediate(function(){
+                self.emit.apply(self, emitArgs);
+              });
+            })(emitArgs);
+          }
 
           if (zmq.STATE_READY != this._zmq.state) {
             this._flushing = false;

--- a/test/test.socket.push-pull.js
+++ b/test/test.socket.push-pull.js
@@ -1,0 +1,35 @@
+
+var zmq = require('../')
+  , should = require('should');
+
+var push = zmq.socket('push')
+  , pull = zmq.socket('pull');
+
+var n = 0;
+
+pull.on('message', function(msg){
+  msg.should.be.an.instanceof(Buffer);
+  switch (n++) {
+    case 0:
+      msg.toString().should.equal('foo');
+      break;
+    case 1:
+      msg.toString().should.equal('bar');
+      break;
+    case 2:
+      msg.toString().should.equal('baz');
+      pull.close();
+      push.close();
+      break;
+  }
+});
+
+var addr = "inproc://stuff";
+
+pull.bind(addr, function(){
+  push.connect(addr);
+
+  push.send('foo');
+  push.send('bar');
+  push.send('baz');
+});


### PR DESCRIPTION
The problem: 

We have an active upstream (PUSH) that will accumulate hundreds of thousands of messages while downstream (PULL) is disconnected. Once downstream nodes become available due to previous implementation we see a huge memory pile up.

Ratio behind the problem is that messages from socket are drained with while loop and message processing is postponed with setImmediate. By the time event loop is able to skip a beat all inbound zmq messages are piled up in this closure:

```
            (function(emitArgs) {
              setImmediate(function(){
                self.emit.apply(self, emitArgs);
              });
            })(emitArgs);
```

Proposed solution is changing only the behaviour of unidirectional receive only sockets by not allowing the messages to be piled up in closures.

I'm not sure of the original intent of setImmediate so I did not remove it completely for other socket types.
