### PR TITLE
Fix 0.11.8

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -599,7 +599,6 @@ namespace zmq {
     Local<Function> cb = NanPersistentToLocal(state->cb);
 
     Socket *socket = ObjectWrap::Unwrap<Socket>(NanPersistentToLocal(state->sock_obj));
-    delete state;
 
     if (--socket->endpoints == 0)
       socket->Unref();
@@ -608,6 +607,7 @@ namespace zmq {
     cb->Call(v8::Context::GetCurrent()->Global(), 1, argv);
     if (try_catch.HasCaught()) FatalException(try_catch);
 
+    delete state;
     delete req;
   }
 


### PR DESCRIPTION
There was a problem with unbind from #232 under 0.11.8 losing the state too early, similar to what @rvagg experienced previously when updating to 0.11.8. This should fix that problem.
