### PR TITLE
change test/run.js to report failing script name

### DIFF
--- a/test/run.js
+++ b/test/run.js
@@ -11,8 +11,14 @@ console.log();
 files.forEach(function(file){
   batch.push(function(done){
     exec('node --expose-gc ' + file, function(err){
-      if (err) return done(err);
-      console.log('  \033[32m✓\033[0m \033[90m%s\033[0m', file);
+      if (err)
+      {
+        console.log('  \033[31m✘\033[0m \033[90m%s\033[0m', file);
+        return done(err);
+      } else
+      {
+        console.log('  \033[32m✓\033[0m \033[90m%s\033[0m', file);
+      }
       done();
     });
   });


### PR DESCRIPTION
test/run.js does not report the failing test file making it difficult to know what test failed when all tests are async.

The build failure is not the fault of this fix. Its an existing issue I have been looking at that this fix helps expose. A race condition seems to exist in test/test.socket.unbind.js and it will fail intermittently. 
