### PR TITLE
Upgrading tests to use should.js v2.1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "bindings": "~1.1.1"
   },
   "devDependencies": {
-    "should": "1.3.0",
+    "should": "2.1.x",
     "batch": "*",
     "jade": "*",
     "dox": "*",

--- a/test/test.exports.js
+++ b/test/test.exports.js
@@ -93,20 +93,20 @@ if (semver.gte(zmq.version, '3.3.0')) {
 }
 
 constants.forEach(function(typeOrProp){
-  zmq['ZMQ_' + typeOrProp].should.be.a('number');
+  zmq['ZMQ_' + typeOrProp].should.be.type('number');
 });
 
 // states
 
 ['STATE_READY', 'STATE_BUSY', 'STATE_CLOSED'].forEach(function(state){
-  zmq[state].should.be.a('number');
+  zmq[state].should.be.type('number');
 })
 
 // constructors
 
-zmq.Context.should.be.a('function');
-zmq.Socket.should.be.a('function');
+zmq.Context.should.be.type('function');
+zmq.Socket.should.be.type('function');
 
 // methods
 
-zmq.socket.should.be.a('function');
+zmq.socket.should.be.type('function');

--- a/test/test.socket.js
+++ b/test/test.socket.js
@@ -10,7 +10,7 @@ zmq.createSocket.should.equal(zmq.socket);
 
 var sock = zmq.socket('req');
 sock.type.should.equal('req');
-sock.close.should.be.a('function');
+sock.close.should.be.type('function');
 
 // setsockopt
 
@@ -27,7 +27,7 @@ sock.getsockopt('backlog').should.equal(75);
 
 // setsockopt sugar
 
-sock.backlog.should.be.a('number');
+sock.backlog.should.be.type('number');
 sock.backlog.should.not.equal(50);
 sock.backlog = 50;
 sock.backlog.should.equal(50);


### PR DESCRIPTION
This makes tests use the current version of should.js (v2.1.1 at the time of writing).
Please merge in and push in some way to NPM to solve Issue https://github.com/JustinTulloss/zeromq.node/issues/261
