### PR TITLE
Fixes #179: fix memory leak of poll_handle object

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -1040,7 +1040,7 @@ namespace zmq {
       this->endpoints = 0;
 
       uv_poll_stop(poll_handle_);
-      uv_close(poll_handle_, on_uv_close);
+      uv_close((uv_handle_t*)poll_handle_, on_uv_close);
     }
   }
 


### PR DESCRIPTION
poll_handle_ object in Socket was never freed.
