### PR TITLE
force int on second param to zmq send

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -469,7 +469,7 @@ Socket.prototype._flush = function() {
       // one sent.
       while (flags & zmq.ZMQ_POLLOUT && this._outgoing.length) {
         args = this._outgoing.shift();
-        this._zmq.send(args[0], args[1]);
+        this._zmq.send( args[0], parseInt( args[1], 10 ) );
         flags = this._ioevents;
       }
     }


### PR DESCRIPTION
the zmq bindings are expecting an integer as the second param. there are some situations when it will complain and crash about getting unexpected value types. 

in particular when tying to send multi-part message via xpub/xsub.