### PR TITLE
Adds a "callback" parameter to Socket::send

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -416,16 +416,22 @@ Socket.prototype.unsubscribe = function(filter) {
  * @api public
  */
 
-Socket.prototype.send = function(msg, flags) {
+Socket.prototype.send = function(msg, flags, callback) {
+  if (typeof flags == 'function') {
+    callback = flags;
+    flags = 0;
+  }
+
   if (Array.isArray(msg)) {
     for (var i = 0, len = msg.length; i < len; i++) {
       this.send(msg[i], i < len - 1
         ? zmq.ZMQ_SNDMORE
-        : flags);
+        : flags,
+        callback);
     }
   } else {
     if (!Buffer.isBuffer(msg)) msg = new Buffer(String(msg), 'utf8');
-    this._outgoing.push([msg, flags || 0]);
+    this._outgoing.push([msg, flags || 0, callback]);
     if (!(flags & zmq.ZMQ_SNDMORE)) this._flush();
   }
 
@@ -485,6 +491,7 @@ Socket.prototype._flush = function() {
       while (flags & zmq.ZMQ_POLLOUT && this._outgoing.length) {
         args = this._outgoing.shift();
         this._zmq.send(args[0], args[1]);
+        args[2] && args[2].call(this);
         flags = this._ioevents;
       }
     }

--- a/test/test.socket.send.callback.js
+++ b/test/test.socket.send.callback.js
@@ -1,0 +1,25 @@
+ 
+var zmq = require('../')
+  , should = require('should');
+
+var push = zmq.socket('push')
+  , pull = zmq.socket('pull');
+
+var sentnoflags = false, sentwithflags = false;
+
+pull.on('message', function(a){
+  sentnoflags.should.equal(true);
+  sentwithflags.should.equal(true);
+  push.close();
+  pull.close();
+});
+
+pull.bind('inproc://stuff', function(){
+  push.connect('inproc://stuff');
+  push.send('hi', function () {
+    sentnoflags = true;
+  });
+  push.send('hi', 0, function () {
+    sentwithflags = true;
+  });
+});


### PR DESCRIPTION
I've found myself needing confirmation that Socket::send has been called. This patch would invoke a callback once the value is written.