### PR TITLE
Exposes the Socket class as zmq.SocketConstructor

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -285,7 +285,7 @@ namespace zmq {
     NanAssignPersistent(String, monitor_symbol, String::NewSymbol("onMonitorEvent"));
 #endif
 
-    target->Set(String::NewSymbol("Socket"), t->GetFunction());
+    target->Set(String::NewSymbol("SocketBinding"), t->GetFunction());
 
     NanAssignPersistent(String, callback_symbol, String::NewSymbol("onReady"));
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -179,10 +179,11 @@ function defaultContext() {
  * @api public
  */
 
-function Socket(type) {
+var Socket =
+exports.Socket = function (type) {
   EventEmitter.call(this);
   this.type = type;
-  this._zmq = new zmq.Socket(defaultContext(), types[type]);
+  this._zmq = new zmq.SocketBinding(defaultContext(), types[type]);
   this._zmq.onReady = this._flush.bind(this);
   this._outgoing = [];
   this._shouldFlush = true;


### PR DESCRIPTION
I've needed to access the Socket constructor to extend its prototype, but this isn't exposed. This patch adds it as "zmq.SocketConstructor", as "Socket" conflicts with the C binding.
