### PR TITLE
adjust settings to compensate for overloaded test servers on travis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build/Release/binding.node: binding.cc binding.gyp
 	npm install
 
 test:
-	$(MOCHA) --expose-gc
+	$(MOCHA) --expose-gc --slow 2000 --timeout 10000
 
 clean:
 	rm -fr build


### PR DESCRIPTION
Going for timeout of 10s and on slow 2s. We are never testing nor can we test for performance on Travis as the servers are all over the place for timings in a given day. All we want to be sure of is that the tests finish and finish correctly not how long they take within reason. If 10s still fails then maybe its time to look into why and maybe it was a deadlock but I would still suggest upping the number again just in case Travis continues to be overloaded.
