### PR TITLE
Send-error contextualization

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -456,7 +456,9 @@ Socket.prototype.send = function(msg, flags) {
     }
   } else {
     if (!Buffer.isBuffer(msg)) msg = new Buffer(String(msg), 'utf8');
-    this._outgoing.push([msg, flags || 0]);
+    flags = flags || 0;
+    this._outgoing.push([msg, flags]);
+
     if (!(flags & zmq.ZMQ_SNDMORE)) {
       try {
         this._flush();
@@ -522,6 +524,9 @@ Socket.prototype._flush = function() {
       try {
         this._zmq.send(args[0], args[1]);
       } catch (sendError) {
+        // add some context to the error
+        sendError.buffer = args[0];
+
         // More chunks were to follow, which we should now drop.
         // This loop will pull off the items up until and including
         // the first item that is not flagged SNDMORE.


### PR DESCRIPTION
Also, fixed the "undefined & zmq.SND_MORE" comparison which worked fine, but probably performs a bit nicer when done against 0 instead of undefined (common case).