### PR TITLE
[Perf local_lat]Don't close the socket immediately

### DIFF
--- a/perf/local_lat.js
+++ b/perf/local_lat.js
@@ -17,5 +17,9 @@ rep.bindSync(bind_to);
 rep.on('message', function (data) {
   assert.equal(data.length, message_size, 'message-size did not match');
   rep.send(data);
-  if (++counter === roundtrip_count) rep.close();
+  if (++counter === roundtrip_count){ 
+    setTimeout( function(){ 
+      rep.close();
+    }, 1000); 
+  }
 })


### PR DESCRIPTION
Closing the socket to fast may lead to data to be not send.
Something similar is done in [remote_thr](https://github.com/JustinTulloss/zeromq.node/blob/master/perf/remote_thr.js#L27L29)