### PR TITLE
_flush cleanup

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -449,24 +449,34 @@ Socket.prototype.unsubscribe = function(filter) {
  */
 
 Socket.prototype.send = function(msg, flags) {
+  flags = flags | 0;
+
   if (Array.isArray(msg)) {
     for (var i = 0, len = msg.length; i < len; i++) {
-      this.send(msg[i], i < len - 1
-        ? zmq.ZMQ_SNDMORE
-        : flags);
+      var part = msg[i];
+
+      if (!Buffer.isBuffer(part)) {
+        part = new Buffer(String(part), 'utf8');
+      }
+
+      this._outgoing.push([part, i < len - 1 ? zmq.ZMQ_SNDMORE : flags]);
     }
   } else {
-    if (!Buffer.isBuffer(msg)) msg = new Buffer(String(msg), 'utf8');
-    this._outgoing.push([msg, flags || 0]);
-    if (!(flags & zmq.ZMQ_SNDMORE)) {
-      try {
-        this._flush();
-      } catch (err) {
-        this.emit('error', err);
-      } finally {
-        this._zmq.pending = this._outgoing.length;
-        this._flushing = false;
-      }
+    if (!Buffer.isBuffer(msg)) {
+      msg = new Buffer(String(msg), 'utf8');
+    }
+
+    this._outgoing.push([msg, flags]);
+  }
+
+  if (!(flags & zmq.ZMQ_SNDMORE)) {
+    try {
+      this._flush();
+    } catch (err) {
+      this.emit('error', err);
+    } finally {
+      this._zmq.pending = this._outgoing.length;
+      this._flushing = false;
     }
   }
 
@@ -477,47 +487,50 @@ Socket.prototype.send = function(msg, flags) {
 // This helper is called from `send` above, and in response to
 // the watcher noticing the signaller fd is readable.
 Socket.prototype._flush = function() {
-  var args;
+  var flags, args, emitArgs;
 
   // Don't allow recursive flush invocation as it can lead to stack
   // exhaustion and write starvation
   if (this._flushing) return;
 
-  if(zmq.STATE_CLOSED == this._zmq.state) return;
-
   this._flushing = true;
   while (true) {
     // If an Async thread that may call a zmq function is in flight
     // do not call any zmq functions.
-    if (this._zmq.state != 0) {
+    if (this._zmq.state !== zmq.STATE_READY) {
       return;
     }
 
-    var emitArgs
-      , flags = this._ioevents;
+    flags = this._zmq.getsockopt(zmq.ZMQ_EVENTS);
 
     if (!this._outgoing.length) flags &= ~zmq.ZMQ_POLLOUT;
-    if (!flags) break;
+    if (!flags) return;
 
     if (flags & zmq.ZMQ_POLLIN) {
         emitArgs = ['message'];
 
         do {
           emitArgs.push(this._zmq.recv());
-        } while (this._receiveMore);
+        } while (this._zmq.getsockopt(zmq.ZMQ_RCVMORE));
 
         // Handle received message immediately to prevent memory leak in driver
         this.emit.apply(this, emitArgs);
 
-        if (zmq.STATE_READY != this._zmq.state) {
-          break;
+        if (this._zmq.state !== zmq.STATE_READY) {
+          return;
         }
     }
 
     // We send as much as possible in one burst so that we don't
     // starve sends if we receive more than one message for each
     // one sent.
-    while (flags & zmq.ZMQ_POLLOUT && this._outgoing.length) {
+    while (this._outgoing.length) {
+      flags = this._zmq.getsockopt(zmq.ZMQ_EVENTS);
+
+      if (!(flags & zmq.ZMQ_POLLOUT)) {
+        return;
+      }
+
       args = this._outgoing.shift();
 
       try {
@@ -533,8 +546,6 @@ Socket.prototype._flush = function() {
 
         throw sendError;
       }
-
-      flags = this._ioevents;
     }
   }
 };

--- a/test/socket.zap.js
+++ b/test/socket.zap.js
@@ -30,7 +30,7 @@ describe('socket.zap', function(){
     try {
       rep.curve_server = 0;
     } catch(e) {
-      console.log("libsoduim seems to be missing; skipping curve test");
+      console.log("libsodium seems to be missing; skipping curve test");
       done();
       return;
     }


### PR DESCRIPTION
- no more recursion for arrays in send()
- _flush no longer uses getters (less magic, and should run a bit faster)
- flags are forced to int
- equalized return and break inside flush (which do the same)

The reason for this PR is that it's hopefully a first little step to moving towards a faster, possibly full C++ implementation of flush.