### PR TITLE
revert commit #ca6d867 (from 2.8 tag) — req reconnection fail on router restart

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -507,7 +507,17 @@ Socket.prototype._flush = function() {
         } while (this._receiveMore);
 
         // Handle received message immediately to prevent memory leak in driver
-        this.emit.apply(this, emitArgs);
+        if (types[this.type] === zmq.ZMQ_SUB || types[this.type] === zmq.ZMQ_PULL) {
+          this.emit.apply(this, emitArgs);
+        } else {
+          // Allows flush to complete before handling received messages.
+          var self = this;
+          (function(emitArgs) {
+            process.nextTick(function(){
+              self.emit.apply(self, emitArgs);
+            });
+          })(emitArgs);
+        }
 
         if (zmq.STATE_READY != this._zmq.state) {
           break;

--- a/test/socket.reconnect.js
+++ b/test/socket.reconnect.js
@@ -1,0 +1,50 @@
+var zmq = require('..')
+  , router = zmq.socket('router')
+  , req = zmq.socket('req')
+  , should = require('should')
+  , tcp = 'tcp://127.0.0.1:3000';
+
+describe('socket reconnect', function() {
+
+    it('should reconnect', function(done) {
+        var reqs = {a: 0, b: 0, c: 0, d: 0, e: 0};
+
+        router.on('message', function(source, _, envelope, data) {
+            // increments reqs flag on req
+            reqs[data]++;
+            router.send([source, '', 'ACK', data]);
+
+            if (data == 'c') {
+                router.unbind(tcp);
+                setTimeout(router.bindSync.bind(router, tcp), 15);
+            }
+        });
+
+        router.bindSync(tcp);
+
+        req
+            .connect(tcp)
+            .monitor(1)
+            .on('message', function(topic, data) {
+                // increments reqs flag on router res
+                reqs[data]++;
+            });
+
+        var delay = 0;
+        Object.keys(reqs).forEach(function(key) {
+            setTimeout(function() {
+                req.send(['REQ', key]);
+            }, delay += 5);
+        });
+
+        var assert = function() {
+            // delay the test until every req get a response
+            if(reqs.e !== 2)
+                return setTimeout(assert, delay += 5);
+
+            reqs.should.eql({a: 2, b: 2, c: 2, d: 2, e: 2});
+            done();
+        };
+        setTimeout(assert, delay += 5);
+    });
+});


### PR DESCRIPTION
This is a revert of commit [#ca6d867](https://github.com/JustinTulloss/zeromq.node/commit/ca6d867) from @utvara `remove receive message delayed handling` which introduces an issue (affecting every version since 2.8.0).

A test is provided to reproduced the problem we have encountered in production: a `req` socket is connected to a `router`. When this `router`restarts (in our case, mainly on version bumping), the `req` is not able to reconnect. What we presume, is that one `request` can be lost — the `req` socket is awaiting for a response, but, because the `router` was restarted in the meantime, this precise `request` will never get an acknowledgement. Thus blocking the `req` socket which needs an ack to this `request` to send next ones.

@utvara, can you please explain why you have change this code on 19 Aug 2014?
Is anyone else experiencing the same issue?