### PR TITLE
Feature/pull with pause resume

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -188,7 +188,9 @@ exports.Socket = function (type) {
   EventEmitter.call(this);
   this.type = type;
   this._zmq = new zmq.SocketBinding(defaultContext(), types[type]);
+  this._pause = false;
   this._zmq.onReady = function() {
+    if (self._pause) return;
     try {
       self._flush();
     } catch (err) {
@@ -207,6 +209,36 @@ exports.Socket = function (type) {
  */
 
 util.inherits(Socket, EventEmitter);
+
+/**
+ * Set pull socket to pause mode
+ * no data will be emit until resume() is called
+ *
+ * @api public
+ */
+
+Socket.prototype.pause = function() {
+  if(this.type != 'pull') {
+    throw new Error('This methode is only supported for socket type pull');
+  }
+
+  this._pause = true;
+}
+
+/**
+ * Set a pull back to normal work mode
+ *
+ * @api public
+ */
+
+Socket.prototype.resume = function() {
+  if(this.type != 'pull') {
+    throw new Error('This methode is only supported for socket type pull');
+  }
+
+  this._pause = false;
+  this._zmq.onReady();
+}
 
 /**
  * Set `opt` to `val`.

--- a/lib/index.js
+++ b/lib/index.js
@@ -188,8 +188,11 @@ exports.Socket = function (type) {
   EventEmitter.call(this);
   this.type = type;
   this._zmq = new zmq.SocketBinding(defaultContext(), types[type]);
+  this._paused = false;
 
-  function onReady() {
+  this._zmq.onReady = function() {
+    if(self._paused) return;
+
     try {
       self._flush();
     } catch (err) {
@@ -198,17 +201,6 @@ exports.Socket = function (type) {
       self._zmq.pending = self._outgoing.length;
       self._flushing = false;
     }
-  }
-
-  if (this.type == 'pull') {
-    this._paused = false;
-    this._zmq.onReady = function() {
-      if(self._paused) return;
-      onReady();
-    }
-  }
-  else {
-    this._zmq.onReady = onReady;
   }
 
   this._outgoing = [];
@@ -228,10 +220,6 @@ util.inherits(Socket, EventEmitter);
  */
 
 Socket.prototype.pause = function() {
-  if(this.type != 'pull') {
-    throw new Error('This methode is only supported for socket type pull');
-  }
-
   this._paused = true;
 }
 
@@ -242,10 +230,6 @@ Socket.prototype.pause = function() {
  */
 
 Socket.prototype.resume = function() {
-  if(this.type != 'pull') {
-    throw new Error('This methode is only supported for socket type pull');
-  }
-
   this._paused = false;
   this._zmq.onReady();
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -188,9 +188,8 @@ exports.Socket = function (type) {
   EventEmitter.call(this);
   this.type = type;
   this._zmq = new zmq.SocketBinding(defaultContext(), types[type]);
-  this._pause = false;
-  this._zmq.onReady = function() {
-    if (self._pause) return;
+
+  function onReady() {
     try {
       self._flush();
     } catch (err) {
@@ -199,6 +198,17 @@ exports.Socket = function (type) {
       self._zmq.pending = self._outgoing.length;
       self._flushing = false;
     }
+  }
+
+  if (this.type == 'pull') {
+    this._pause = false;
+    this._zmq.onReady = function() {
+      if(self._pause) return;
+      onReady();
+    }
+  }
+  else {
+    this._zmq.onReady = onReady;
   }
 
   this._outgoing = [];

--- a/lib/index.js
+++ b/lib/index.js
@@ -201,9 +201,9 @@ exports.Socket = function (type) {
   }
 
   if (this.type == 'pull') {
-    this._pause = false;
+    this._paused = false;
     this._zmq.onReady = function() {
-      if(self._pause) return;
+      if(self._paused) return;
       onReady();
     }
   }
@@ -232,7 +232,7 @@ Socket.prototype.pause = function() {
     throw new Error('This methode is only supported for socket type pull');
   }
 
-  this._pause = true;
+  this._paused = true;
 }
 
 /**
@@ -246,7 +246,7 @@ Socket.prototype.resume = function() {
     throw new Error('This methode is only supported for socket type pull');
   }
 
-  this._pause = false;
+  this._paused = false;
   this._zmq.onReady();
 }
 

--- a/test/socket.push-pull.js
+++ b/test/socket.push-pull.js
@@ -38,4 +38,89 @@ describe('socket.push-pull', function(){
     });
   });
 
+
+  it('should not emit messages after pasue()', function(done){
+      var push = zmq.socket('push')
+        , pull = zmq.socket('pull');
+
+      var n = 0;
+
+      pull.on('message', function(msg){
+        if(n++ === 0) {
+          msg.toString().should.equal('foo');
+        }
+        else{
+          should.not.exist(msg);
+        }
+      });
+
+      var addr = "inproc://pause_stuff";
+
+      pull.bind(addr, function(){
+        push.connect(addr);
+
+        push.send('foo');
+        pull.pause()
+        push.send('bar');
+        push.send('baz');
+      });
+
+      setTimeout(function (){
+        pull.close();
+        push.close();
+        done();
+      }, 100);
+  });
+
+
+
+  it('should emit messages after resume()', function(done){
+    var push = zmq.socket('push')
+      , pull = zmq.socket('pull');
+
+    var n = 0;
+
+    checkNoMessages = function (msg){
+      should.not.exist(msg);
+    }
+
+    checkMessages = function (msg){
+      msg.should.be.an.instanceof(Buffer);
+      switch (n++) {
+        case 0:
+          msg.toString().should.equal('foo');
+          break;
+        case 1:
+          msg.toString().should.equal('bar');
+          break;
+        case 2:
+          msg.toString().should.equal('baz');
+          pull.close();
+          push.close();
+          done();
+          break;
+      }
+    }
+
+    pull.on('message', checkNoMessages)
+
+    var addr = "inproc://resume_stuff";
+
+    pull.bind(addr, function(){
+      push.connect(addr);
+      pull.pause()
+
+      push.send('foo');
+      push.send('bar');
+      push.send('baz');
+
+      setTimeout(function (){
+        pull.removeListener('message', checkNoMessages)
+        pull.on('message', checkMessages)
+        pull.resume()
+      }, 100)
+
+    });
+
+  });
 });

--- a/test/socket.push-pull.js
+++ b/test/socket.push-pull.js
@@ -80,11 +80,11 @@ describe('socket.push-pull', function(){
 
     var n = 0;
 
-    checkNoMessages = function (msg){
+    function checkNoMessages(msg){
       should.not.exist(msg);
     }
 
-    checkMessages = function (msg){
+    function checkMessages(msg){
       msg.should.be.an.instanceof(Buffer);
       switch (n++) {
         case 0:


### PR DESCRIPTION
related to issue #380
but it doesn't provide a real stream interface. It just extends the pull socket API with `pause()` and `resume()` and prevents to internal `_flush` call in case of pause.