### PR TITLE
Make sure Socket _flush is not getting called recursively

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -195,7 +195,6 @@ exports.Socket = function (type) {
       self.emit('error', err);
     } finally {
       self._zmq.pending = self._outgoing.length;
-      self._flushing = false;
     }
   }
 
@@ -272,7 +271,6 @@ Socket.prototype.bind = function(addr, cb) {
       self.emit('error', err);
     } finally {
       self._zmq.pending = self._outgoing.length;
-      self._flushing = false;
     }
 
   });
@@ -320,7 +318,6 @@ Socket.prototype.unbind = function(addr, cb) {
         self.emit('error', err);
       } finally {
         self._zmq.pending = self._outgoing.length;
-        self._flushing = false;
       }
     });
   }
@@ -476,7 +473,6 @@ Socket.prototype.send = function(msg, flags) {
       this.emit('error', err);
     } finally {
       this._zmq.pending = this._outgoing.length;
-      this._flushing = false;
     }
   }
 
@@ -498,27 +494,32 @@ Socket.prototype._flush = function() {
     // If an Async thread that may call a zmq function is in flight
     // do not call any zmq functions.
     if (this._zmq.state !== zmq.STATE_READY) {
+      this._flushing = false;
       return;
     }
 
     flags = this._zmq.getsockopt(zmq.ZMQ_EVENTS);
 
     if (!this._outgoing.length) flags &= ~zmq.ZMQ_POLLOUT;
-    if (!flags) return;
+    if (!flags) {
+      this._flushing = false;
+      return
+    };
 
     if (flags & zmq.ZMQ_POLLIN) {
-        emitArgs = ['message'];
+      emitArgs = ['message'];
 
-        do {
-          emitArgs.push(this._zmq.recv());
-        } while (this._zmq.getsockopt(zmq.ZMQ_RCVMORE));
+      do {
+        emitArgs.push(this._zmq.recv());
+      } while (this._zmq.getsockopt(zmq.ZMQ_RCVMORE));
 
-        // Handle received message immediately to prevent memory leak in driver
-        this.emit.apply(this, emitArgs);
+      // Handle received message immediately to prevent memory leak in driver
+      this.emit.apply(this, emitArgs);
 
-        if (this._zmq.state !== zmq.STATE_READY) {
-          return;
-        }
+      if (this._zmq.state !== zmq.STATE_READY) {
+        this._flushing = false;
+        return;
+      }
     }
 
     // We send as much as possible in one burst so that we don't
@@ -528,6 +529,7 @@ Socket.prototype._flush = function() {
       flags = this._zmq.getsockopt(zmq.ZMQ_EVENTS);
 
       if (!(flags & zmq.ZMQ_POLLOUT)) {
+        this._flushing = false;
         return;
       }
 
@@ -543,11 +545,12 @@ Socket.prototype._flush = function() {
         while (args && (args[1] & zmq.ZMQ_SNDMORE)) {
           args = this._outgoing.shift();
         }
-
+        this._flushing = false;
         throw sendError;
       }
     }
   }
+  this._flushing = false;
 };
 
 /**


### PR DESCRIPTION
Under load a server that sends a response from within the `message` event can cause the `_flush` method to get called recursively, causing a dump.
> node: ../src/node_object_wrap.h:60: static T* node::ObjectWrap::Unwrap(v8::Handle<v8::Object>) [with T = node::Buffer]: Assertion `!handle.IsEmpty()' failed.
Aborted (core dumped).

Here is a test that reproduce the error:

```javascript
var cluster = require('cluster')
  , zmq = require('../')
  , port = 'tcp://127.0.0.1:12345';

if (cluster.isMaster) {
  // Fork 5 clients
  for (var i = 0; i < 5; i++) cluster.fork();

  //router = server
  var socket = zmq.socket('router');
  socket.identity = 'server' + process.pid;
  socket.bind(port, function() {
    console.log('Server listening !');
    var i = 0;
    socket.on('message', function(envelope, data) {
      console.log(++i);
      socket.send([envelope, data*2]);
    });
  });

  cluster.on('death', function(worker) {
    console.log('worker ' + worker.pid + ' died');
  });

} else {
  //dealer = client
  var socket = zmq.socket('dealer');
  socket.identity = 'client' + process.pid;
  socket.connect(port);
  console.log('Client connected');

  setInterval(function() {
    var value = Math.floor(Math.random()*100);
    socket.send(value);
  }, 1);

  socket.on('message', function(data) {
//    console.log('Client got res:', data.toString());
  });
}
```
