### PR TITLE
trying to implement the (ZMQ_IMMEDIATE) option

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -1242,6 +1242,7 @@ namespace zmq {
     opts_binary.insert(49); // ZMQ_CURVE_SECRETKEY
     opts_binary.insert(50); // ZMQ_CURVE_SERVERKEY
     opts_binary.insert(55); // ZMQ_ZAP_DOMAIN
+    opts_int.insert(56); // ZMQ_IMMEDIATE
     #endif
 
     NODE_DEFINE_CONSTANT(target, ZMQ_CAN_DISCONNECT);

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,6 +37,7 @@ var types = exports.types = {
   , router: zmq.ZMQ_ROUTER
   , pair: zmq.ZMQ_PAIR
   , stream: zmq.ZMQ_STREAM
+  , immediate: zmq.ZMQ_IMMEDIATE
 };
 
 var longOptions = {
@@ -89,6 +90,7 @@ var longOptions = {
   , ZMQ_ZAP_DOMAIN: 55
   , ZMQ_IO_THREADS: 1
   , ZMQ_MAX_SOCKETS: 2
+  , ZMQ_IMMEDIATE: 56
 };
 
 Object.keys(longOptions).forEach(function(name){

--- a/lib/index.js
+++ b/lib/index.js
@@ -37,7 +37,6 @@ var types = exports.types = {
   , router: zmq.ZMQ_ROUTER
   , pair: zmq.ZMQ_PAIR
   , stream: zmq.ZMQ_STREAM
-  , immediate: zmq.ZMQ_IMMEDIATE
 };
 
 var longOptions = {
@@ -134,6 +133,7 @@ var opts = exports.options = {
   , curve_secretkey: zmq.ZMQ_CURVE_SECRETKEY
   , curve_serverkey: zmq.ZMQ_CURVE_SERVERKEY
   , zap_domain: zmq.ZMQ_ZAP_DOMAIN
+  , immediate: zmq.ZMQ_IMMEDIATE
 };
 
 /**

--- a/test/exports.js
+++ b/test/exports.js
@@ -95,6 +95,13 @@ describe('exports', function(){
         'ROUTER_RAW'
       ]);
     }
+    
+    // 4.0 and above.
+    if (semver.gte(zmq.version, '4.0.0')) {
+      constants.concat([
+        'IMMEDIATE'
+      ]);
+    }
 
     constants.forEach(function(typeOrProp){
       zmq['ZMQ_' + typeOrProp].should.be.a.Number;

--- a/test/socket.immediate.js
+++ b/test/socket.immediate.js
@@ -1,0 +1,19 @@
+var zmq = require('..')
+  , should = require('should')
+  , semver = require('semver');
+  
+describe('socket.immediate', function(){
+  
+  it('should support immediate socket option', function (done){
+    
+    if (semver.gte(zmq.version, '4.0.0')) {
+      
+      var push = zmq.socket('push');
+      push.setsockopt('immediate', 1);
+      
+    } else {
+      done();
+      return console.warn('stream socket type in libzmq v4+');
+    }
+  });
+});


### PR DESCRIPTION
This PR is a attempt to implement the 0mq option (ZMQ_IMMEDIATE)
Im not sure 100% if I did it the correct way, but it was requested by [ronkorving](https://github.com/ronkorving).

Im not expert neither c++ nor v8, and I need this option to be implmented urgently, so if I did a mistake, I'll be thankful for you if you correct it and do it for me.

for testing I did the below:
```javascript
var zmq = require('zeromq.node');
var socket = zmq.socket('push');
socket.setsockopt('immediate', 1);
```
but I got the error
```
Error: Invalid argument
at Socket.setsockopt (/home/kj/Development/Node_Test/node_modules/zeromq.node/lib/index.js:222:13)
at initClient (/home/kj/Development/Node_Test/zClient.js:10:9)
at Object. (/home/kj/Development/Node_Test/zClient.js:42:2)
at Module._compile (module.js:456:26)
at Object.Module._extensions..js (module.js:474:10)
at Module.load (module.js:356:32)
at Function.Module._load (module.js:312:12)
at Function.Module.runMain (module.js:497:10)
at startup (node.js:119:16)
at node.js:906:3
```