### PR TITLE
Test updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,6 @@ language: node_js
 node_js:
  - "0.8"
  - "0.10"
- - "0.11"
+ - "0.12"
+ - "iojs"
 script: travis_retry npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 env:
  - ZMQ="git://github.com/zeromq/zeromq2-x.git"
  - ZMQ="git://github.com/zeromq/zeromq3-x.git -b v3.1.0"
- - ZMQ="git://github.com/zeromq/zeromq3-x.git -b v3.2.4"
- - ZMQ="git://github.com/zeromq/zeromq4-x.git -b v4.0.3" SODIUM="git://github.com/jedisct1/libsodium.git -b 0.4.5"
+ - ZMQ="git://github.com/zeromq/zeromq3-x.git -b v3.2.5"
+ - ZMQ="git://github.com/zeromq/zeromq4-x.git -b v4.0.5" SODIUM="git://github.com/jedisct1/libsodium.git -b 0.4.5"
 before_install:
  - sudo apt-get install uuid-dev
  - '[ -z "$SODIUM" ] || git clone --depth 1 $SODIUM libsodium'

--- a/test/socket.push-pull.js
+++ b/test/socket.push-pull.js
@@ -39,7 +39,7 @@ describe('socket.push-pull', function(){
   });
 
 
-  it('should not emit messages after pasue()', function(done){
+  it('should not emit messages after pause()', function(done){
       var push = zmq.socket('push')
         , pull = zmq.socket('pull');
 


### PR DESCRIPTION
* Removed Node 0.11 from Travis, added Node 0.12 and io.js
* Bumped ZMQ versions used by Travis
* Fixed typo in pause/resume test