### PR TITLE
return NanThrowErrors

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -390,7 +390,10 @@ namespace zmq {
 
   void
   Socket::UV_PollCallback(uv_poll_t* handle, int status, int events) {
-    if (status != 0) NanThrowError("I/O status: socket not ready !=0 ");
+    if (status != 0) {
+      NanThrowError("I/O status: socket not ready !=0 ");
+      return;
+    }
     Socket* s = static_cast<Socket*>(handle->data);
     s->CallbackIfReady();
   }
@@ -439,9 +442,14 @@ namespace zmq {
 
         // get our next frame it may have the target address and safely copy to our buffer
         zmq_msg_init (&msg2);
-        if (zmq_msg_more(&msg1) == 0) NanThrowError(ExceptionFromError());
-        if (zmq_recvmsg (s->monitor_socket_, &msg2, 0) == -1)
+        if (zmq_msg_more(&msg1) == 0) {
           NanThrowError(ExceptionFromError());
+          return;
+        }
+        if (zmq_recvmsg (s->monitor_socket_, &msg2, 0) == -1) {
+          NanThrowError(ExceptionFromError());
+          return;
+        }
         // protect from overflow
         size_t len = zmq_msg_size(&msg2);
         // MIN message size and buffer size with null padding


### PR DESCRIPTION
corrects the control flow issue we overlooked in PR #401.

credit for this PR is due to: @kkoopa, see inline comment: https://github.com/JustinTulloss/zeromq.node/pull/401/files#r27674094