### PR TITLE
Update nan to 1.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "http://github.com/JustinTulloss/zeromq.node.git"
   },
   "dependencies": {
-    "nan": "~1.5.0",
+    "nan": "~1.8.4",
     "bindings": "~1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
With nan updated, we're now able to build against io.js and with electron headers.