### PR TITLE
bump nan version for io.js 2.x compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zmq",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Bindings for node.js and io.js to ZeroMQ",
   "main": "index",
   "repository": {
@@ -8,7 +8,7 @@
     "url": "http://github.com/JustinTulloss/zeromq.node.git"
   },
   "dependencies": {
-    "nan": "~1.5.0",
+    "nan": "~1.8.4",
     "bindings": "~1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
With the release of io.js v2.0.0 and the associated V8 upgrade, install fails:

```
  CXX(target) Release/obj.target/zmq/binding.o
In file included from ../binding.cc:37:
In file included from ../node_modules/nan/nan.h:74:
In file included from ../node_modules/nan/nan_new.h:181:
../node_modules/nan/nan_implementation_12_inl.h:172:66: error: too many arguments to function call, expected at most 2, have 4
  return v8::Signature::New(v8::Isolate::GetCurrent(), receiver, argc, argv);
         ~~~~~~~~~~~~~~~~~~                                      ^~~~~~~~~~
/Users/leon/.node-gyp/2.0.0/deps/v8/include/v8.h:4188:3: note: 'New' declared here
  static Local<Signature> New(
  ^
1 error generated.
make: *** [Release/obj.target/zmq/binding.o] Error 1
```

Bumping nan version fixes the issue.