### PR TITLE
Read all available monitor messages on each timer callback

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -411,15 +411,15 @@ namespace zmq {
   Socket::MonitorEvent(uint16_t event_id, int32_t event_value, char *event_endpoint) {
     NanScope();
 
-    Local<Value> argv[3];
-    argv[0] = NanNew<Integer>(event_id);
-    argv[1] = NanNew<Integer>(event_value);
-    argv[2] = NanNew<String>(event_endpoint);
-
     Local<Value> callback_v = NanObjectWrapHandle(this)->Get(NanNew(monitor_symbol));
     if (!callback_v->IsFunction()) {
       return;
     }
+
+    Local<Value> argv[3];
+    argv[0] = NanNew<Integer>(event_id);
+    argv[1] = NanNew<Integer>(event_value);
+    argv[2] = NanNew<String>(event_endpoint);
 
     NanMakeCallback(NanObjectWrapHandle(this), callback_v.As<Function>(), 3, argv);
   }
@@ -428,13 +428,13 @@ namespace zmq {
   Socket::MonitorError(const char *error_msg) {
     NanScope();
 
-    Local<Value> argv[1];
-    argv[0] = NanNew<String>(error_msg);
-
     Local<Value> callback_v = NanObjectWrapHandle(this)->Get(NanNew(monitor_error));
     if (!callback_v->IsFunction()) {
       return;
     }
+
+    Local<Value> argv[1];
+    argv[0] = NanNew<String>(error_msg);
 
     NanMakeCallback(NanObjectWrapHandle(this), callback_v.As<Function>(), 1, argv);
   }

--- a/binding.cc
+++ b/binding.cc
@@ -1013,6 +1013,10 @@ namespace zmq {
       return;
     }
 
+    // Passing NULL as addr will tell zmq to stop monitor
+    zmq_socket_monitor(this->socket_, NULL, ZMQ_EVENT_ALL);
+
+    // Close the monitor socket and stop timer
     if (zmq_close(this->monitor_socket_) < 0)
       throw std::runtime_error(ErrorMessage());
     uv_timer_stop(this->monitor_handle_);

--- a/binding.cc
+++ b/binding.cc
@@ -1022,7 +1022,10 @@ namespace zmq {
 
   NAN_METHOD(Socket::Unmonitor) {
     NanScope();
-    GET_SOCKET(args);
+    
+    // We can't use the GET_SOCKET macro here as it requries the socket to be open,
+    // which might not always be the case
+    Socket* socket = GetSocket(args);
     socket->Unmonitor();
     NanReturnUndefined();
   }

--- a/binding.cc
+++ b/binding.cc
@@ -503,11 +503,12 @@ namespace zmq {
       }
     }
 
-    // If there was no error we reset the monitor timer, otherwise raise the monitor error event and stop the monitor
-    if (error == NULL) {
+    // If there was no error and we still monitor we reset the monitor timer
+    if (error == NULL && s->monitor_handle_ != NULL) {
       uv_timer_start(s->monitor_handle_, reinterpret_cast<uv_timer_cb>(Socket::UV_MonitorCallback), s->timer_interval_, 0);
     }
-    else {
+    // If error raise the monitor error event and stop the monitor
+    else if (error != NULL) {
       s->Unmonitor();
       s->MonitorError(error);
     }

--- a/binding.cc
+++ b/binding.cc
@@ -428,7 +428,7 @@ namespace zmq {
     item.socket = s->monitor_socket_;
     item.events = ZMQ_POLLIN;
 
-    if (zmq_poll(&item, 1, 0)) {
+    while (zmq_poll(&item, 1, 0)) {
       zmq_msg_init (&msg1);
       if (zmq_recvmsg (s->monitor_socket_, &msg1, ZMQ_DONTWAIT) > 0) {
         char event_endpoint[1025];
@@ -446,11 +446,11 @@ namespace zmq {
         zmq_msg_init (&msg2);
         if (zmq_msg_more(&msg1) == 0) {
           NanThrowError(ExceptionFromError());
-          return;
+          continue;
         }
         if (zmq_recvmsg (s->monitor_socket_, &msg2, 0) == -1) {
           NanThrowError(ExceptionFromError());
-          return;
+          continue;
         }
         // protect from overflow
         size_t len = zmq_msg_size(&msg2);

--- a/lib/index.js
+++ b/lib/index.js
@@ -407,11 +407,12 @@ Socket.prototype.disconnect = function(addr) {
  * Enable monitoring of a Socket
  *
  * @param {Number} timer interval in ms > 0 or Undefined for default
+ * @param {Number} The maximum number of events to read on each interval, default is 1, use 0 for reading all events
  * @return {Socket} for chaining
  * @api public
  */
 
-Socket.prototype.monitor = function(interval) {
+Socket.prototype.monitor = function(interval, numOfEvents) {
   if (zmq.ZMQ_CAN_MONITOR) {
     var self = this;
 
@@ -419,7 +420,7 @@ Socket.prototype.monitor = function(interval) {
       self.emit(events[event_id], event_value, event_endpoint_addr);
     }
 
-    this._zmq.monitor(interval);
+    this._zmq.monitor(interval, numOfEvents);
   } else {
     throw new Error('Monitoring support disabled check zmq version is > 3.2.1 and recompile this addon');
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -420,6 +420,10 @@ Socket.prototype.monitor = function(interval, numOfEvents) {
       self.emit(events[event_id], event_value, event_endpoint_addr);
     }
 
+    self._zmq.onMonitorError = function(error) {
+      self.emit('monitor_error', error);
+    }
+
     this._zmq.monitor(interval, numOfEvents);
   } else {
     throw new Error('Monitoring support disabled check zmq version is > 3.2.1 and recompile this addon');

--- a/test/socket.monitor.js
+++ b/test/socket.monitor.js
@@ -2,15 +2,13 @@ var zmq = require('..')
   , should = require('should')
   , semver = require('semver');
 
-describe('socket.monitor', function(){
-  it('should be able to monitor the socket', function(done){
-    /* no test if monitor is not available */
-    if (!zmq.ZMQ_CAN_MONITOR) {
-      console.log("monitoring not enabled skipping test");
-      done();
-      return;
-    }
+describe('socket.monitor', function() {
+  if (!zmq.ZMQ_CAN_MONITOR) {
+    console.log("monitoring not enabled skipping test");
+    return;
+  }
 
+  it('should be able to monitor the socket', function(done) {
     var rep = zmq.socket('rep')
       , req = zmq.socket('req')
       , events = [];
@@ -21,31 +19,26 @@ describe('socket.monitor', function(){
       rep.send('world');
     });
 
-    rep.on('listen', function(event_value, event_endpoint_addr){
-      console.log("listen %s,%d",event_endpoint_addr,event_value);
-      event_endpoint_addr.toString().should.equal('tcp://127.0.0.1:5423');
-      events.push('listen');
+    var testedEvents = ['listen', 'accept', 'disconnect', 'close'];
+    testedEvents.forEach(function(e) {
+      rep.on(e, function(event_value, event_endpoint_addr) {
+        // Test the endpoint addr arg
+        event_endpoint_addr.toString().should.equal('tcp://127.0.0.1:5423');
+
+        // If this is a disconnect event we can now close the rep socket
+        if (e === 'disconnect') {
+          rep.close();
+        }
+
+        testedEvents.pop();
+        if (testedEvents.length === 0) {
+          rep.unmonitor();
+          done();
+        }
+      });
     });
 
-    rep.on('accept', function(event_value, event_endpoint_addr){
-      console.log("accept %s,%d",event_endpoint_addr,event_value);
-      event_endpoint_addr.toString().should.equal('tcp://127.0.0.1:5423');
-      events.push('accept');
-    });
-
-    rep.on('disconnect', function(event_value, event_endpoint_addr){
-      console.log("disconnect %s,%d",event_endpoint_addr, event_value);
-      event_endpoint_addr.toString().should.equal('tcp://127.0.0.1:5423');
-      events.push('disconnect');
-    });
-
-    rep.on('close', function(event_value, event_endpoint_addr){
-      console.log("closed %s,%d",event_endpoint_addr, event_value);
-      event_endpoint_addr.toString().should.equal('tcp://127.0.0.1:5423');
-      events.push('close');
-    });
-
-    /* enable monitoring for this socket */
+    // enable monitoring for this socket
     rep.monitor();
 
     rep.bind('tcp://127.0.0.1:5423');
@@ -57,18 +50,55 @@ describe('socket.monitor', function(){
         msg.should.be.an.instanceof(Buffer);
         msg.toString().should.equal('world');
         req.close();
-
-        // wait a few for the "disconnect" to reach us (can't close rep yet)
-        setTimeout((function() {
-          rep.close();
-          // wait a few for the "close" to reach us then call unmonitor to release the handle
-          setTimeout(function() {
-            rep.unmonitor();
-            events.length.should.equal(4);
-            done();
-	      }, 500);
-        }), 500);
       });
     });
+  });
+
+  it('should use default interval and numOfEvents', function(done) {
+    var req = zmq.socket('req');
+    req.setsockopt(zmq.ZMQ_RECONNECT_IVL, 5); // We want a quick connect retry from zmq
+
+    // We will try to connect to a non-existing server, zmq will issue events: "connect_retry", "close", "connect_retry"
+    // The connect_retry will be issued immediately after the close event, so we will measure the time between the close
+    // event and connect_retry event, those should >= 10 (this will tell us that we are reading 1 event at a time from
+    // the monitor socket).
+
+    var closeTime;
+    req.on('close', function() {
+	    closeTime = Date.now();
+    });
+
+    req.on('connect_retry', function() {
+      var diff = Date.now() - closeTime;
+      req.unmonitor();
+      req.close();
+      diff.should.be.within(10, 20);
+      done();
+    });
+
+    req.monitor();
+    req.connect('tcp://127.0.0.1:5423');
+  });
+
+  it('should read multiple events on monitor interval', function(done) {
+    var req = zmq.socket('req');
+    req.setsockopt(zmq.ZMQ_RECONNECT_IVL, 5);
+    var closeTime;
+    req.on('close', function() {
+      closeTime = Date.now();
+    });
+
+    req.on('connect_retry', function() {
+      var diff = Date.now() - closeTime;
+      req.unmonitor();
+      req.close();
+      diff.should.be.within(0, 5);
+      done();
+    });
+
+    // This should read all available messages from the queue, and we expect that "close" and "connect_retry" will be
+    // read on the same interval (for further details see the comment in the previous test)
+    req.monitor(10, 0);
+    req.connect('tcp://127.0.0.1:5423');
   });
 });


### PR DESCRIPTION
Currently, on each callback of the monitor timer, only one message is read from the monitor socket, this can lead to a situation where the events reporting start to fall behind.
For example (our case):
* A dealer socker
* The monitor interval is set to 1000ms
* The ZMQ_RECONNECT_IVL is set to 1000ms, so is the ZMQ_RECONNECT_IVL_MAX.
* The server goes down, zmq tries to reconnect, about every 1 second it sends 3 events on the monitor socket (connect_retry, connect_delay, close), but only 1 message is being read (every 1 second), eventually the server goes up, the socket gets reconnected (can see the port is taken), but the monitor events are falling behind and it can take quite some time until the `connected` event will be reached.

This PR makes the following changes:
1. On each monitor timer callback it tries to read all the available messages from the monitor socket and raise the events
2. Since each monitor callback now can take more time (as we read all messages and not just one), I removed the interval from `uv_timer_start` and manually reset the timer when all messages from the monitor socket processed (basically switching from `setInterval` to `setTimeout`)
3. See the comment on line 461, are we missing a call to `zmq_msg_close(&msg2)` there ??

What do you think?