### PR TITLE
Adding zmq_curve_keypair to the interface.

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -26,6 +26,7 @@
 #include <node_version.h>
 #include <node_buffer.h>
 #include <zmq.h>
+#include <zmq_utils.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -1180,6 +1181,26 @@ namespace zmq {
     NanReturnValue(NanNew<String>(version_info));
   }
 
+#if ZMQ_VERSION_MAJOR >= 4
+   static NAN_METHOD(ZmqCurveKeypair) {
+    NanScope();
+
+    char public_key [41];
+    char secret_key [41];
+
+    int rc = zmq_curve_keypair( public_key, secret_key);
+    if (rc < 0) {
+      return NanThrowError("zmq_curve_keypair operation failed. Method support in libzmq v4+ -with-libsodium.");
+    }
+
+    Local<Object> obj = NanNew<Object>();
+    obj->Set(NanNew<String>("public"), NanNew<String>(public_key));
+    obj->Set(NanNew<String>("secret"), NanNew<String>(secret_key));
+
+    NanReturnValue(obj);
+  }
+#endif
+
   static void
   Initialize(Handle<Object> target) {
     NanScope();
@@ -1289,6 +1310,9 @@ namespace zmq {
     NODE_DEFINE_CONSTANT(target, STATE_CLOSED);
 
     NODE_SET_METHOD(target, "zmqVersion", ZmqVersion);
+    #if ZMQ_VERSION_MAJOR >= 4
+    NODE_SET_METHOD(target, "zmqCurveKeypair", ZmqCurveKeypair);
+    #endif
 
     Context::Initialize(target);
     Socket::Initialize(target);

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,12 @@ exports = module.exports = zmq;
 exports.version = zmq.zmqVersion();
 
 /**
+ * Expose zmq_curve_keypair
+ */
+
+exports.curveKeypair = zmq.zmqCurveKeypair;
+
+/**
  * Map of socket types.
  */
 

--- a/test/exports.js
+++ b/test/exports.js
@@ -8,6 +8,20 @@ describe('exports', function(){
     semver.valid(zmq.version).should.be.ok;
   });
 
+  it('should generate valid curve keypair', function(done) {
+    if (!semver.gte(zmq.version, '4.0.0')) {
+      done();
+      return console.warn('Test requires libzmq >= 4 compiled with libsodium');
+    }
+    var curve = zmq.curveKeypair();
+    should.exist(curve);
+    should.exist(curve.public);
+    should.exist(curve.secret);
+    curve.public.length.should.equal(40);
+    curve.secret.length.should.equal(40);
+    done();
+  }); 
+
   it('should export socket types and options', function(){
     // All versions.
     var constants = [


### PR DESCRIPTION
This is my naive try to address #414. I have no previous experience neither with NaN nor with V8 so please point at my errors and I do my best to address them.

The motivation for the PR is described in the issue referred. I would like to generate the keys needed for Curve without using an external tool and as this method is part oz ZeroMQ since 4.0 I felt it appropriate to put it in to the node binding as well.

I updated the headers in the include folder from [zeromq/zeromq4-x](https://github.com/zeromq/zeromq4-x). I haven't updated the dlls and libs as I couldn't figure out where to get them from.