### PR TITLE
Allow npm test without depending on "make"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,9 @@
 
-TESTS = $(wildcard test/test.*.js)
-MOCHA = ./node_modules/.bin/mocha
-
 build/Release/binding.node: binding.cc binding.gyp
 	npm install
 
 test:
-	$(MOCHA) --expose-gc --slow 2000 --timeout 600000
+	npm test
 
 clean:
 	rm -fr build

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">=0.8"
   },
   "scripts": {
-    "test": "make test"
+    "test": "mocha --expose-gc --slow 2000 --timeout 600000"
   },
   "keywords": ["zeromq", "zmq", "0mq", "ømq", "libzmq", "native", "binding", "addon"],
   "author": "Justin Tulloss <justin.tulloss@gmail.com> (http://justin.harmonize.fm)",


### PR DESCRIPTION
This makes it easier to test in Windows