### PR TITLE
Zmq immediate option

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -1285,7 +1285,6 @@ namespace zmq {
     opts_int.insert(35); // ZMQ_TCP_KEEPALIVE_CNT
     opts_int.insert(36); // ZMQ_TCP_KEEPALIVE_IDLE
     opts_int.insert(37); // ZMQ_TCP_KEEPALIVE_INTVL
-    opts_int.insert(39); // ZMQ_DELAY_ATTACH_ON_CONNECT
     opts_int.insert(40); // ZMQ_XPUB_VERBOSE
     opts_int.insert(41); // ZMQ_ROUTER_RAW
     opts_int.insert(42); // ZMQ_IPV6
@@ -1332,6 +1331,9 @@ namespace zmq {
     opts_binary.insert(49); // ZMQ_CURVE_SECRETKEY
     opts_binary.insert(50); // ZMQ_CURVE_SERVERKEY
     opts_binary.insert(55); // ZMQ_ZAP_DOMAIN
+    opts_int.insert(39); // ZMQ_IMMEDIATE
+    #else
+    opts_int.insert(39); // ZMQ_DELAY_ATTACH_ON_CONNECT
     #endif
 
     NODE_DEFINE_CONSTANT(target, ZMQ_CAN_DISCONNECT);

--- a/lib/index.js
+++ b/lib/index.js
@@ -138,6 +138,7 @@ var opts = exports.options = {
   , curve_secretkey: zmq.ZMQ_CURVE_SECRETKEY
   , curve_serverkey: zmq.ZMQ_CURVE_SERVERKEY
   , zap_domain: zmq.ZMQ_ZAP_DOMAIN
+  , immediate: zmq.ZMQ_DELAY_ATTACH_ON_CONNECT
 };
 
 /**

--- a/test/socket.immediate.js
+++ b/test/socket.immediate.js
@@ -1,0 +1,39 @@
+var zmq = require('..')
+  , should = require('should')
+  , semver = require('semver');
+
+
+describe('socket.immediate', function() {
+	
+	it('should test ZMQ_IMMEDIATE socket option', function(done) {
+		
+		var msgsToSend = 5
+		  , receivedMsgs = 0;
+		
+		var push = zmq.socket('push');
+		push.setsockopt('immediate', 1);
+		
+		push.connect('tcp://127.0.0.1:5423');
+		
+		for(var i=0; i<msgsToSend; i++) {
+			push.send('message #'+i);
+		}
+		
+		var pull = zmq.socket('pull');
+		
+		var pull = zmq.socket('pull');
+		
+		pull.on('message', function(data) {
+			receivedMsgs += 1;
+		});
+		
+		pull.bind('tcp://127.0.0.1:5423', function(err){
+			if (err) throw err;
+		});
+		
+		setTimeout(function(){
+			receivedMsgs.should.equal(0);
+			done();
+		}, 1000);
+	});
+});


### PR DESCRIPTION
This is a trying to apply ZMQ_IMMEDIATE option.

kindly notice that (ZMQ_DELAY_ATTACH_ON_CONNECT deprecated, and renamed to ZMQ_IMMEDIATE) according of [zmq 4 release notes](http://zeromq.org/docs:changes-4-0-0)
