### PR TITLE
also rm node_modules during clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ test:
 	npm test
 
 clean:
-	rm -fr build
+	rm -fr build node_modules
 
 distclean:
 	node-gyp clean


### PR DESCRIPTION
clear the `node_modules` slate in addition to the `build` directory during a `make clean`. good to do in scenarios where you might switch node versions before building