### PR TITLE
fix stream test on osx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ binding.Makefile
 binding.target.gyp.mk
 gyp-mac-tool
 out/
+zeromq-*
+libsodium-*
+ldlocal

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,40 @@
+sudo: false
+
+language: c
+
 addons:
   apt:
     sources:
     - ubuntu-toolchain-r-test
     packages:
+    - gcc-4.8
     - g++-4.8
+    - uuid-dev
+
 env:
- - ZMQ="git://github.com/zeromq/zeromq2-x.git"
- - ZMQ="git://github.com/zeromq/zeromq3-x.git -b v3.1.0"
- - ZMQ="git://github.com/zeromq/zeromq3-x.git -b v3.2.5"
- - ZMQ="git://github.com/zeromq/zeromq4-x.git -b v4.0.5" SODIUM="git://github.com/jedisct1/libsodium.git -b 0.4.5"
+ - ZMQ="2.2.0"
+ - ZMQ="3.2.5"
+ - ZMQ="4.0.5"
+ - ZMQ="4.1.3"
+
 before_install:
+ - export CC=gcc-4.8
  - export CXX=g++-4.8
- - sudo apt-get install uuid-dev
- - '[ -z "$SODIUM" ] || git clone --depth 1 $SODIUM libsodium'
- - '[ -z "$SODIUM" ] || cd libsodium'
- - '[ -z "$SODIUM" ] || ./autogen.sh'
- - '[ -z "$SODIUM" ] || ./configure'
- - '[ -z "$SODIUM" ] || make'
- - '[ -z "$SODIUM" ] || sudo make install'
- - '[ -z "$SODIUM" ] || cd ..'
- - git clone --depth 1 $ZMQ zmqlib
- - cd zmqlib
- - ./autogen.sh
- - ./configure
- - make
- - sudo make install
- - sudo /sbin/ldconfig
- - cd ..
-language: node_js
-node_js:
- - "0.8"
- - "0.10"
- - "0.12"
- - "4"
- - "5"
+ - mkdir ldlocal
+ - export LDHACK=`pwd`/ldlocal
+ - rm -rf ~/.nvm ~/.npm && git clone https://github.com/creationix/nvm.git ~/.nvm
+ - source ~/.nvm/nvm.sh && nvm install node
+ - node -v
+
+install:
+  - ./nosudo
+  - ls -la
+# language: node_js
+# node_js:
+#  - "0.8"
+#  - "0.10"
+#  - "0.12"
+#  - "4"
+#  - "5"
+
 script: travis_retry npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,21 +14,46 @@ addons:
 env:
  - ZMQ="2.2.0"
  - ZMQ="3.2.5"
- - ZMQ="4.0.5"
- - ZMQ="4.1.3"
+ - ZMQ="4.0.5" SODIUM="http://download.libsodium.org/libsodium/releases/libsodium-1.0.5.tar.gz"
+ - ZMQ="4.1.3" SODIUM="http://download.libsodium.org/libsodium/releases/libsodium-1.0.5.tar.gz"
 
 before_install:
+ - mkdir ldlocal
  - export CC=gcc-4.8
  - export CXX=g++-4.8
- - mkdir ldlocal
  - export LDHACK=`pwd`/ldlocal
+ - echo $LDHACK
+ - export LDFLAGS=-L$LDHACK/lib
+ - export CFLAGS=-I$LDHACK/include
+ - export LD_RUN_PATH=$LDHACK/lib
+ - export LD_LIBRARY_PATH=$LDHACK/lib
+ - export PKG_CONFIG_PATH=$LDHACK/lib/pkgconfig
+ - echo $PKG_CONFIG_PATH
+ - wget http://download.zeromq.org/zeromq-$ZMQ.tar.gz
+ - tar xzvf zeromq-$ZMQ.tar.gz
+ - '[ -z "$SODIUM" ] || wget $SODIUM'
+ - '[ -z "$SODIUM" ] || tar xzvf libsodium-1.0.5.tar.gz'
+ - '[ -z "$SODIUM" ] || cd libsodium-1.0.5'
+ - '[ -z "$SODIUM" ] || ./autogen.sh'
+ - '[ -z "$SODIUM" ] || ./configure --prefix=$LDHACK'
+ - '[ -z "$SODIUM" ] || make'
+ - '[ -z "$SODIUM" ] || make install'
+ - '[ -z "$SODIUM" ] || cd ..'
+ - '[ -z "$SODIUM" ] || export LIBS=-lsodium && export sodium_CFLAGS=$CFLAGS && export sodium_LIBS=$LDFLAGS'
+ - cd zeromq-$ZMQ
+ - ./autogen.sh
+ - if [[ -z "$SODIUM" ]]; then ./configure --prefix=$LDHACK; else ./configure --prefix=$LDHACK --with-libsodium=$LDHACK; fi
+ - make
+ - make install
+ - cd ..
  - rm -rf ~/.nvm ~/.npm && git clone https://github.com/creationix/nvm.git ~/.nvm
  - source ~/.nvm/nvm.sh && nvm install node
  - node -v
 
 install:
-  - ./nosudo
-  - ls -la
+  - env LD_LIBRARY_PATH=$LDHACK/lib LD_RUN_PATH=$LDHACK/lib PKG_CONFIG_PATH=$LDHACK/lib/pkgconfig LDFLAGS=-L$LDHACK/lib CFLAGS=-I$LDHACK/lib/include npm install
+  # probably need to add an if-then here for libsodium linked npm install
+
 # language: node_js
 # node_js:
 #  - "0.8"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,9 @@ test:
 	npm test
 
 clean:
-	rm -fr build node_modules
+	rm -fr build node_modules ldlocal
+	rm -rf zeromq-4.1.3 zeromq-4.1.3.tar.gz libsodium-1.0.5 libsodium-1.0.5.tar.gz
+	mkdir ldlocal
 
 distclean:
 	node-gyp clean

--- a/nosudo
+++ b/nosudo
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+ /**
+ * LD hacking around sudo install for better travis infrastructure
+ */
+
+var exec    = require('child_process').exec;
+var sources = {
+  'zeromq'    : 'http://download.zeromq.org/',
+  'libsodium' : 'http://download.libsodium.org/libsodium/releases/'
+}
+var env    = [ '',
+  'LDFLAGS=-L$LDHACK/lib',
+  'CFLAGS=-I$LDHACK/include',
+  'LD_RUN_PATH=$LDHACK/lib',
+  'LD_LIBRARY_PATH=$LDHACK/lib',
+  'PKG_CONFIG_PATH=$LDHACK/lib/pkgconfig'
+].join('øexport ').split('ø'); env.shift();
+
+function make (dir, wlibsodium) { // the w/libsodium flag for ./configure
+  var str = 'cd ' + dir
+      + ' && ./autogen.sh'
+      + ' && ' + env.join(' && ') + ' && '; // shared env exports
+
+  str += wlibsodium ? 'export LIBS=-lsodium && export sodium_CFLAGS=$CFLAGS && '
+                      + 'export sodium_LIBS=$LDFLAGS && '
+                      + './configure --with-libsodium=' + process.env.LDHACK
+                    : './configure';
+  str += ' --prefix=' + process.env.LDHACK + ' && make && make install';
+  console.log('running:\n%s\n', str);
+  return str;
+}
+
+var version = process.env.ZMQ;
+if (Number(version.split('.')[0]) < 4) {
+  // simple install --without-libsodium
+  dl('zeromq', version, function (err, dirname) {
+    if (err) throw err;
+    exec(make(dirname), npminstall);
+  });
+} else {
+  // get a libsodium first
+  dl('libsodium', '1.0.5', function (err, dirname) {
+    if (err) throw err;
+    exec(make(dirname), withLibsodium);
+  });
+  function withLibsodium (err, stdo) {
+    if (err) throw err;
+    console.log(stdo, '\n\nlibsodium installed, downloading zeromq');
+    dl('zeromq', version, function (err, dirname) {
+      if (err) throw err;
+      exec(make(dirname, true), npminstall);
+    });
+  }
+  function npminstall (err, stdo, stder) {
+    if (err) throw err;
+    console.log(stder, stdo,'\nzeromq library linking complete.\ninstalling zmq')
+    var ldconfig = 'env LD_LIBRARY_PATH=$LDHACK/lib LD_RUN_PATH=$LDHACK/lib '
+        + 'PKG_CONFIG_PATH=$LDHACK/lib/pkgconfig LDFLAGS=-L$LDHACK/lib '
+        + 'CFLAGS=-I$LDHACK/lib/include';
+    ldconfig += version < 4 ? '' : ' LIBS=-lsodium';
+    exec(ldconfig + ' npm install', function(){
+      console.log('now using libzmq', require('./').zmqVersion())
+    });
+  }
+}
+
+// pkg tarballs piped to WriteStream, unpacked to their new dir after 'end' event
+// dl's last param, fn cb tells us when its done, that's where we're headed next
+function dl (lib, ver, fn) {
+  var filename = lib + '-' + ver + '.tar.gz';
+
+  require('http').get(sources[lib] + filename, function (res) {
+    res.on('error', fn);
+    res.on('end', function() {
+      exec( 'tar xzvf ' + filename, function (err) {
+        if(err) fn(err);
+        console.log('download and unpack tar complete: %s\n%s configure make'
+          + ' and install... this may take a few minutes', lib+'-'+ver, lib );
+        fn(null, lib + '-' + ver);
+      });
+    });
+
+    res.pipe(require('fs').createWriteStream(filename));
+  });
+}


### PR DESCRIPTION
issue #462 "zmq on Osx El Capitan" brought to my attention a broken stream test on osx.

I think maybe they've changed the http parser a bit since this test was originally written, since doing some different style header parsing on the response from a `STREAM` socket type seems to resolve it