### PR TITLE
Test against Node 4 and 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,5 +32,6 @@ node_js:
  - "0.8"
  - "0.10"
  - "0.12"
- - "iojs"
+ - "4"
+ - "5"
 script: travis_retry npm test


### PR DESCRIPTION
Dropped support for io.js in .travis.yml, and added Node.js 4 and 5.