### PR TITLE
Rely on node-pre-gyp, prebuild binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ binding.Makefile
 binding.target.gyp.mk
 gyp-mac-tool
 out/
+
+builds/

--- a/binding.gyp
+++ b/binding.gyp
@@ -71,6 +71,17 @@
           ],
         }],
       ]
+    },
+    {
+      "target_name": "action_after_build",
+      "type": "none",
+      "dependencies": [ "<(module_name)" ],
+      "copies": [
+        {
+          "files": [ "<(PRODUCT_DIR)/<(module_name).node" ],
+          "destination": "<(module_path)"
+        }
+      ]
     }
   ]
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,8 +2,13 @@
  * Module dependencies.
  */
 
+// Replaces `var zmq = require('./bindings')`;
+var binary = require('node-pre-gyp');
+var path = require('path');
+var bindingPath = binary.find(path.resolve(path.join(__dirname, '../package.json')));
+var zmq = require(bindingPath);
+
 var EventEmitter = require('events').EventEmitter
-  , zmq = require('bindings')('zmq.node')
   , util = require('util');
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@
 // Replaces `var zmq = require('./bindings')`;
 var binary = require('node-pre-gyp');
 var path = require('path');
-var bindingPath = binary.find(path.resolve(path.join(__dirname, '../package.json')));
+var bindingPath = binary.find(path.resolve(path.join(__dirname, '..', 'package.json')));
 var zmq = require(bindingPath);
 
 var EventEmitter = require('events').EventEmitter

--- a/package.json
+++ b/package.json
@@ -8,21 +8,39 @@
     "url": "http://github.com/JustinTulloss/zeromq.node.git"
   },
   "dependencies": {
+    "bindings": "~1.2.1",
     "nan": "~2.1.0",
-    "bindings": "~1.2.1"
+    "node-pre-gyp": "^0.6.18"
   },
+  "bundledDependencies": ["node-pre-gyp"],
   "devDependencies": {
-    "should": "2.1.x",
+    "aws-sdk": "^2.2.26",
+    "mocha": "~1.13.0",
     "semver": "~4.1.1",
-    "mocha": "~1.13.0"
+    "should": "2.1.x"
   },
   "engines": {
     "node": ">=0.8"
   },
   "scripts": {
-    "test": "mocha --expose-gc --slow 2000 --timeout 600000"
+    "test": "mocha --expose-gc --slow 2000 --timeout 600000",
+    "install": "node-pre-gyp install --fallback-to-build"
   },
-  "keywords": ["zeromq", "zmq", "0mq", "ømq", "libzmq", "native", "binding", "addon"],
+  "binary": {
+    "module_name": "zmq",
+		"module_path": "./builds",
+    "host": "https://zmq-prebuilt.s3-us-west-1.amazonaws.com"
+  },
+  "keywords": [
+    "zeromq",
+    "zmq",
+    "0mq",
+    "ømq",
+    "libzmq",
+    "native",
+    "binding",
+    "addon"
+  ],
   "license": "MIT",
   "author": "Justin Tulloss <justin.tulloss@gmail.com> (http://justin.harmonize.fm)",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "binary": {
     "module_name": "zmq",
-    "module_path": "./builds"
+    "module_path": "./builds",
+    "host": "NONE"
   },
   "keywords": [
     "zeromq",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "binary": {
     "module_name": "zmq",
-		"module_path": "./builds",
+    "module_path": "./builds",
     "host": "https://zmq-prebuilt.s3-us-west-1.amazonaws.com"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "bundledDependencies": ["node-pre-gyp"],
   "devDependencies": {
-    "aws-sdk": "^2.2.26",
     "mocha": "~1.13.0",
     "semver": "~4.1.1",
     "should": "2.1.x"
@@ -28,8 +27,7 @@
   },
   "binary": {
     "module_name": "zmq",
-    "module_path": "./builds",
-    "host": "https://zmq-prebuilt.s3-us-west-1.amazonaws.com"
+    "module_path": "./builds"
   },
   "keywords": [
     "zeromq",


### PR DESCRIPTION
Hey all, I've been wanting to make installation and usage of zmq across runtimes and versions *super easy*. Currently this goes well if the user has their development environment setup. For my own cases, I want to use `zmq` in Electron apps, Atom, and of course server side without needing a build environment.

My ideal use case is that `zmq.node` gets fetched for them and they're able to rely on that directly, across all platforms, runtimes (Electron, node), and targets (versions of the runtimes). Hopefully this would help with #360, relying on a better experience instead of assuming people will read documentation.

The major con to this PR is that if you want to link to your own zmq headers, we'd need to have two different options. However, node-pre-gyp can always do a full build if requested `node-pre-gyp build --build-from-source`.

I'm more than happy to help setup the Appveyor and Travis setup so these can be shipped in automation on tagged builds.

Let me know what you think!