### PR TITLE
Massive perf boost

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -181,6 +181,100 @@ function defaultContext() {
 };
 
 /**
+ * A batch consists of 1 or more message parts with their flags that need to be sent as one unit
+ */
+
+function OutBatch() {
+  this.content = [];      // buf, flags, buf, flags, ...
+  this.cbs = [];          // callbacks
+  this.isClosed = false;  // true if the last message does not have SNDMORE in its flags, false otherwise
+  this.next = null;       // next batch (for linked list of batches)
+}
+
+OutBatch.prototype.append = function (buf, flags, cb) {
+  if (!Buffer.isBuffer(buf)) {
+    buf = new Buffer(String(buf), 'utf8');
+  }
+
+  this.content.push(buf, flags);
+
+  if (cb) {
+    this.cbs.push(cb);
+  }
+
+  if ((flags & zmq.SNDMORE) === 0) {
+    this.isClosed = true;
+  }
+};
+
+OutBatch.prototype.invokeError = function (socket, error) {
+  var returned = false;
+  for (var i = 0; i < this.cbs.length; i += 1) {
+    this.cbs[i].call(socket, error);
+    returned = true;
+  }
+
+  if (!returned) {
+    throw error;
+  }
+};
+
+OutBatch.prototype.invokeSent = function (socket) {
+  for (var i = 0; i < this.cbs.length; i += 1) {
+    this.cbs[i].call(socket);
+  }
+};
+
+
+function BatchList() {
+  this.firstBatch = null;
+  this.lastBatch = null;
+  this.length = 0;
+}
+
+BatchList.prototype.canSend = function () {
+  return this.firstBatch ? this.firstBatch.isClosed : false;
+};
+
+BatchList.prototype.append = function (buf, flags, cb) {
+  var batch = this.lastBatch;
+
+  if (!batch || batch.isClosed) {
+    batch = new OutBatch();
+
+    if (this.lastBatch) {
+      this.lastBatch.next = batch;
+    }
+
+    this.lastBatch = batch;
+
+    if (!this.firstBatch) {
+      this.firstBatch = batch;
+    }
+
+    this.length += 1;
+  }
+
+  batch.append(buf, flags, cb);
+};
+
+BatchList.prototype.fetch = function () {
+  var batch = this.firstBatch;
+  if (batch && batch.isClosed) {
+    this.firstBatch = batch.next;
+    this.length -= 1;
+    return batch;
+  }
+  return undefined;
+};
+
+BatchList.prototype.restore = function (batch) {
+  this.firstBatch = batch;
+  this.length += 1;
+};
+
+
+/**
  * Create a new socket of the given `type`.
  *
  * @constructor
@@ -195,20 +289,14 @@ exports.Socket = function (type) {
   this.type = type;
   this._zmq = new zmq.SocketBinding(defaultContext(), types[type]);
   this._paused = false;
+  this._isFlushingReads = false;
+  this._isFlushingWrites = false;
+  this._outgoing = new BatchList();
 
-  this._zmq.onReady = function() {
-    if(self._paused) return;
-
-    try {
-      self._flush();
-    } catch (err) {
-      self.emit('error', err);
-    } finally {
-      self._zmq.pending = self._outgoing.length;
-    }
-  }
-
-  this._outgoing = [];
+  this._zmq.onReady = function(readable, writable) {
+    if (readable) self._flushReads();
+    if (writable) self._flushWrites();
+  };
 };
 
 /**
@@ -218,8 +306,9 @@ exports.Socket = function (type) {
 util.inherits(Socket, EventEmitter);
 
 /**
- * Set pull socket to pause mode
+ * Set socket to pause mode
  * no data will be emit until resume() is called
+ * all send() calls will be queued
  *
  * @api public
  */
@@ -229,14 +318,15 @@ Socket.prototype.pause = function() {
 }
 
 /**
- * Set a pull back to normal work mode
+ * Set a socket back to normal work mode
  *
  * @api public
  */
 
 Socket.prototype.resume = function() {
   this._paused = false;
-  this._zmq.onReady();
+  this._flushReads();
+  this._flushWrites();
 }
 
 Socket.prototype.read = function() {
@@ -258,6 +348,7 @@ Socket.prototype.read = function() {
 
   return null;
 }
+
 
 /**
  * Set `opt` to `val`.
@@ -314,17 +405,16 @@ Object.keys(opts).forEach(function(name){
 
 Socket.prototype.bind = function(addr, cb) {
   var self = this;
-  self._zmq.bind(addr, function(err) {
-    try {
-      self._flush();
-      self.emit('bind', addr);
-      cb && cb(err);
-    } catch (err) {
-      self.emit('error', err);
-    } finally {
-      self._zmq.pending = self._outgoing.length;
+  this._zmq.bind(addr, function(err) {
+    if (err) {
+      return cb && cb(err);
     }
 
+    self._flushReads();
+    self._flushWrites();
+
+    self.emit('bind', addr);
+    cb && cb();
   });
   return this;
 };
@@ -338,11 +428,7 @@ Socket.prototype.bind = function(addr, cb) {
  */
 
 Socket.prototype.bindSync = function(addr) {
-  try {
-    this._zmq.bindSync(addr);
-  } catch (err) {
-    throw err;
-  }
+  this._zmq.bindSync(addr);
 
   return this;
 };
@@ -361,17 +447,18 @@ Socket.prototype.bindSync = function(addr) {
 Socket.prototype.unbind = function(addr, cb) {
   if (zmq.ZMQ_CAN_UNBIND) {
     var self = this;
-    self._zmq.unbind(addr, function(err) {
-      try {
-        self._flush();
-        self.emit('unbind', addr);
-        cb && cb(err);
-      } catch (err) {
-        self.emit('error', err);
-      } finally {
-        self._zmq.pending = self._outgoing.length;
+    this._zmq.unbind(addr, function(err) {
+      if (err) {
+        return cb && cb(err);
       }
+      self.emit('unbind', addr);
+
+      self._flushReads();
+      self._flushWrites();
+      cb && cb();
     });
+  } else {
+    cb && cb();
   }
   return this;
 };
@@ -386,11 +473,7 @@ Socket.prototype.unbind = function(addr, cb) {
 
 Socket.prototype.unbindSync = function(addr) {
   if (zmq.ZMQ_CAN_UNBIND) {
-    try {
-      this._zmq.unbindSync(addr);
-    } catch (err) {
-      throw err;
-    }
+    this._zmq.unbindSync(addr);
   }
   return this;
 }
@@ -493,6 +576,7 @@ Socket.prototype.unsubscribe = function(filter) {
   return this;
 };
 
+
 /**
  * Send the given `msg`.
  *
@@ -508,124 +592,105 @@ Socket.prototype.send = function(msg, flags, cb) {
 
   if (Array.isArray(msg)) {
     for (var i = 0, len = msg.length; i < len; i++) {
-      var part = msg[i];
       var isLast = i === len - 1;
+      var msgFlags = isLast ? flags : flags | zmq.ZMQ_SNDMORE;
+      var callback = isLast ? cb : undefined;
 
-      if (!Buffer.isBuffer(part)) {
-        part = new Buffer(String(part), 'utf8');
-      }
-
-      this._outgoing.push([part, isLast ? flags : zmq.ZMQ_SNDMORE, isLast ? cb : undefined]);
+      this._outgoing.append(msg[i], msgFlags, callback);
     }
   } else {
-    if (!Buffer.isBuffer(msg)) {
-      msg = new Buffer(String(msg), 'utf8');
-    }
-
-    this._outgoing.push([msg, flags, cb]);
+    this._outgoing.append(msg, flags, cb);
   }
 
-  if (!(flags & zmq.ZMQ_SNDMORE)) {
-    try {
-      this._flush();
-    } catch (err) {
-      this.emit('error', err);
-    } finally {
-      this._zmq.pending = this._outgoing.length;
-    }
+  if (this._outgoing.canSend()) {
+    this._zmq.pending = true;
+    this._flushWrites();
+  } else {
+    this._zmq.pending = false;
   }
 
   return this;
 };
 
 
-// The workhorse that does actual send and receive operations.
-// This helper is called from `send` above, and in response to
-// the watcher noticing the signaller fd is readable.
-Socket.prototype._flush = function() {
-  var flags, args, emitArgs, errorSent;
-
-  // Don't allow recursive flush invocation as it can lead to stack
-  // exhaustion and write starvation
-  if (this._flushing) return;
-
-  this._flushing = true;
-  while (true) {
-    // If an Async thread that may call a zmq function is in flight
-    // do not call any zmq functions.
-    if (this._zmq.state !== zmq.STATE_READY) {
-      this._flushing = false;
-      return;
-    }
-
-    flags = this._zmq.getsockopt(zmq.ZMQ_EVENTS);
-
-    if (!this._outgoing.length) flags &= ~zmq.ZMQ_POLLOUT;
-    if (!flags) {
-      this._flushing = false;
-      return;
-    };
-
-    var emitArgs = this.read();
-    if (emitArgs) {
-      emitArgs.unshift('message');
-      // Handle received message immediately to prevent memory leak in driver
-      this.emit.apply(this, emitArgs);
-    }
-
-    if (this._zmq.state !== zmq.STATE_READY) {
-      this._flushing = false;
-      return;
-    }
-
-    // We send as much as possible in one burst so that we don't
-    // starve sends if we receive more than one message for each
-    // one sent.
-    while (this._outgoing.length) {
-      flags = this._zmq.getsockopt(zmq.ZMQ_EVENTS);
-
-      if (!(flags & zmq.ZMQ_POLLOUT)) {
-        this._flushing = false;
-        return;
-      }
-
-      args = this._outgoing.shift();
-
-      try {
-        this._zmq.send(args[0], args[1]);
-
-        if (args[2]) {
-          args[2].call(this);
-        }
-      } catch (sendError) {
-        errorSent = false;
-
-        if (args[2]) {
-          errorSent = true;
-          args[2].call(this, sendError);
-        }
-
-        // If more chunks were to follow, we need to drop all of them.
-        // This loop will pull off the items up until and including
-        // the first item that is not flagged SNDMORE.
-
-        while (args && (args[1] & zmq.ZMQ_SNDMORE)) {
-          args = this._outgoing.shift();
-
-          if (args && args[2]) {
-            errorSent = true;
-            args[2].call(this, sendError);
-          }
-        }
-
-        if (!errorSent) {
-          this._flushing = false;
-          throw sendError;
-        }
-      }
-    }
+Socket.prototype._flushRead = function () {
+  var message = this._zmq.readv(); // can throw
+  if (!message) {
+    return false;
   }
-  this._flushing = false;
+
+  // Handle received message immediately to prevent memory leak in driver
+  if (message.length === 1) {
+    // hot path
+    this.emit('message', message[0]);
+  } else {
+    this.emit.apply(this, ['message'].concat(message));
+  }
+  return true;
+};
+
+Socket.prototype._flushWrite = function () {
+  var batch = this._outgoing.fetch();
+  if (!batch) {
+    this._zmq.pending = false;
+    return false;
+  }
+
+  try {
+    if (this._zmq.sendv(batch.content)) {
+      this._zmq.pending = this._outgoing.canSend();
+      batch.invokeSent(this);
+      return true;
+    }
+
+    this._outgoing.restore(batch);
+    return false;
+  } catch (sendError) {
+    this._zmq.pending = this._outgoing.canSend();
+    batch.invokeError(this, sendError); // can throw
+    return false;
+  }
+};
+
+
+Socket.prototype._flushReads = function() {
+  if (this._paused || this._isFlushingReads) return;
+
+  this._isFlushingReads = true;
+
+  var received;
+
+  do {
+    try {
+      received = this._flushRead();
+    } catch (error) {
+      this._isFlushingReads = false;
+      this.emit('error', error); // can throw
+      return;
+    }
+  } while (received);
+
+  this._isFlushingReads = false;
+};
+
+Socket.prototype._flushWrites = function() {
+  if (this._paused || this._isFlushingWrites) return;
+
+  this._isFlushingWrites = true;
+
+  var sent;
+
+  do {
+    try {
+      sent = this._flushWrite();
+    } catch (error) {
+      this._isFlushingWrites = false;
+      this.emit('error', error); // can throw
+      return;
+    }
+  } while (sent);
+
+  this._isFlushingWrites = false;
 };
 
 /**

--- a/test/socket.events.js
+++ b/test/socket.events.js
@@ -1,6 +1,5 @@
 var zmq = require('..')
-  , should = require('should')
-  , semver = require('semver');
+  , should = require('should');
 
 describe('socket.events', function(){
 
@@ -14,11 +13,12 @@ describe('socket.events', function(){
       rep.send('world');
     });
 
-    rep.bind('inproc://stuff');
+    rep.bind('inproc://stuffevents', function (error) {
+      if (error) throw error;
+    });
 
     rep.on('bind', function(){
-      req.connect('inproc://stuff');
-      req.send('hello');
+      req.connect('inproc://stuffevents');
       req.on('message', function(msg){
         msg.should.be.an.instanceof(Buffer);
         msg.toString().should.equal('world');
@@ -26,6 +26,7 @@ describe('socket.events', function(){
         rep.close();
         done();
       });
+      req.send('hello');
     });
   });
 });

--- a/test/socket.messages.js
+++ b/test/socket.messages.js
@@ -31,7 +31,8 @@ describe('socket.messages', function(){
       }
     });
 
-    pull.bind('inproc://stuff_ssm', function(){
+    pull.bind('inproc://stuff_ssm', function (error) {
+      if (error) throw error;
       push.connect('inproc://stuff_ssm');
       push.send('string');
       push.send(15.99);
@@ -49,7 +50,8 @@ describe('socket.messages', function(){
       done();
     });
 
-    pull.bind('inproc://stuff_ssmm', function(){
+    pull.bind('inproc://stuff_ssmm', function (error) {
+      if (error) throw error;
       push.connect('inproc://stuff_ssmm');
       push.send(['string', 15.99, new Buffer('buffer')]);
     });
@@ -67,7 +69,8 @@ describe('socket.messages', function(){
       done();
     });
 
-    pull.bind('inproc://stuff_sss', function(){
+    pull.bind('inproc://stuff_sss', function (error) {
+      if (error) throw error;
       push.connect('inproc://stuff_sss');
       push.send(['tobi', 'loki'], zmq.ZMQ_SNDMORE);
       push.send(['jane', 'luna'], zmq.ZMQ_SNDMORE);
@@ -104,7 +107,8 @@ describe('socket.messages', function(){
       pull.setsockopt(zmq.ZMQ_HWM, 1);
     }
 
-    push.bind('tcp://127.0.0.1:12345', function () {
+    push.bind('tcp://127.0.0.1:12345', function (error) {
+      if (error) throw error;
       push.send('string');
       push.send(15.99);
       push.send(new Buffer('buffer'));
@@ -129,7 +133,8 @@ describe('socket.messages', function(){
       }
     });
 
-    pull.bind('inproc://stuff_ssmm', function(){
+    pull.bind('inproc://stuff_ssmm', function (error) {
+      if (error) throw error;
       push.connect('inproc://stuff_ssmm');
 
       push.send('hello', null, cb);

--- a/test/socket.monitor.js
+++ b/test/socket.monitor.js
@@ -41,7 +41,9 @@ describe('socket.monitor', function() {
     // enable monitoring for this socket
     rep.monitor();
 
-    rep.bind('tcp://127.0.0.1:5423');
+    rep.bind('tcp://127.0.0.1:5423', function (error) {
+      if (error) throw error;
+    });
 
     rep.on('bind', function(){
       req.connect('tcp://127.0.0.1:5423');

--- a/test/socket.pair.js
+++ b/test/socket.pair.js
@@ -1,6 +1,5 @@
 var zmq = require('..')
-  , should = require('should')
-  , semver = require('semver');
+  , should = require('should');
 
 describe('socket.pair', function(){
 
@@ -9,8 +8,9 @@ describe('socket.pair', function(){
       , pairC = zmq.socket('pair');
 
     var n = 0;
-    pairB.on('message', function (msg){
+    pairB.on('message', function (msg) {
       msg.should.be.an.instanceof(Buffer);
+
       switch (n++) {
         case 0:
           msg.toString().should.equal('foo');
@@ -27,14 +27,16 @@ describe('socket.pair', function(){
       }
     });
 
-    pairC.on('message', function (msg){
+    pairC.on('message', function (msg) {
       msg.should.be.an.instanceof(Buffer);
       msg.toString().should.equal('barnacle');
     })
 
-    var addr = "inproc://stuff";
+    var addr = "inproc://stuffpair";
 
-    pairB.bind(addr, function(){
+    pairB.bind(addr, function (error) {
+      if (error) throw error;
+
       pairC.connect(addr);
       pairB.send('barnacle');
       pairC.send('foo');

--- a/test/socket.pub-sub.js
+++ b/test/socket.pub-sub.js
@@ -34,7 +34,8 @@ describe('socket.pub-sub', function(){
 
     var addr = "inproc://stuff_ssps";
 
-    sub.bind(addr, function(){
+    sub.bind(addr, function (error) {
+      if (error) throw error;
       pub.connect(addr);
 
       // The connect is asynchronous, and messages published to a non-
@@ -75,7 +76,8 @@ describe('socket.pub-sub', function(){
       }
     });
 
-    sub.bind('inproc://stuff_sspsf', function(){
+    sub.bind('inproc://stuff_sspsf', function (error) {
+      if (error) throw error;
       pub.connect('inproc://stuff_sspsf');
 
       // See comments on pub-sub test.

--- a/test/socket.push-pull.js
+++ b/test/socket.push-pull.js
@@ -29,7 +29,8 @@ describe('socket.push-pull', function(){
 
     var addr = "inproc://stuff";
 
-    pull.bind(addr, function(){
+    pull.bind(addr, function (error) {
+      if (error) throw error;
       push.connect(addr);
 
       push.send('foo');
@@ -56,7 +57,8 @@ describe('socket.push-pull', function(){
 
       var addr = "inproc://pause_stuff";
 
-      pull.bind(addr, function(){
+      pull.bind(addr, function (error) {
+        if (error) throw error;
         push.connect(addr);
 
         push.send('foo');
@@ -79,7 +81,8 @@ describe('socket.push-pull', function(){
       var addr = "inproc://pause_stuff";
 
       var messages = ['bar', 'foo'];
-      pull.bind(addr, function(){
+      pull.bind(addr, function (error) {
+        if (error) throw error;
         push.connect(addr);
 
         pull.pause()
@@ -132,7 +135,8 @@ describe('socket.push-pull', function(){
 
     var addr = "inproc://resume_stuff";
 
-    pull.bind(addr, function(){
+    pull.bind(addr, function (error) {
+      if (error) throw error;
       push.connect(addr);
       pull.pause()
 

--- a/test/socket.req-rep.js
+++ b/test/socket.req-rep.js
@@ -1,6 +1,5 @@
 var zmq = require('..')
-  , should = require('should')
-  , semver = require('semver');
+  , should = require('should');
 
 describe('socket.req-rep', function(){
   it('should support req-rep', function(done){
@@ -13,8 +12,9 @@ describe('socket.req-rep', function(){
       rep.send('world');
     });
 
-    rep.bind('inproc://stuff', function(){
-      req.connect('inproc://stuff');
+    rep.bind('inproc://stuffreqrep', function (error) {
+      if (error) throw error;
+      req.connect('inproc://stuffreqrep');
       req.send('hello');
       req.on('message', function(msg){
         msg.should.be.an.instanceof(Buffer);
@@ -40,7 +40,8 @@ describe('socket.req-rep', function(){
           rep.send('world');
         });
 
-        rep.bind('inproc://' + n, function(){
+        rep.bind('inproc://' + n, function (error) {
+          if (error) throw error;
           req.connect('inproc://' + n);
           req.send('hello');
           req.on('message', function(msg){

--- a/test/socket.stream.js
+++ b/test/socket.stream.js
@@ -38,7 +38,8 @@ describe('socket.stream', function(){
       });
 
       var addr = '127.0.0.1:5513';
-      stream.bind('tcp://'+addr, function(){
+      stream.bind('tcp://'+addr, function (error) {
+        if (error) throw error;
         //send non-peer request to zmq, like an http GET method with URI path
         http.get('http://'+addr+'/aRandomRequestPath', function (httpMsg){
 

--- a/test/socket.unbind.js
+++ b/test/socket.unbind.js
@@ -14,10 +14,10 @@ describe('socket.unbind', function(){
       , c = zmq.socket('dealer');
 
     var message_count = 0;
-    a.bind('tcp://127.0.0.1:5420', function (err) {
-      if (err) throw err;
-      a.bind('tcp://127.0.0.1:5421', function (err) {
-        if (err) throw err;
+    a.bind('tcp://127.0.0.1:5420', function (error) {
+      if (error) throw error;
+      a.bind('tcp://127.0.0.1:5421', function (error) {
+        if (error) throw error;
         b.connect('tcp://127.0.0.1:5420');
         b.send('Hello from b.');
         c.connect('tcp://127.0.0.1:5421');
@@ -38,7 +38,9 @@ describe('socket.unbind', function(){
     a.on('message', function(msg) {
       message_count++;
       if (msg.toString() === 'Hello from b.') {
-        a.unbind('tcp://127.0.0.1:5420');
+        a.unbind('tcp://127.0.0.1:5420', function (error) {
+          if (error) throw error;
+        });
       } else if (msg.toString() === 'Final message from c.') {
         message_count.should.equal(4);
         a.close();

--- a/test/socket.zap.js
+++ b/test/socket.zap.js
@@ -30,7 +30,7 @@ describe('socket.zap', function(){
     try {
       rep.curve_server = 0;
     } catch(e) {
-      console.log("libsodium seems to be missing; skipping curve test");
+      console.log("libsodium seems to be missing (skipping curve test)");
       done();
       return;
     }
@@ -51,7 +51,8 @@ describe('socket.zap', function(){
     rep.curve_secretkey = serverPrivateKey;
     rep.mechanism.should.eql(2);
 
-    rep.bind(port, function(){
+    rep.bind(port, function (error) {
+      if (error) throw error;
       req.curve_serverkey = serverPublicKey;
       req.curve_publickey = clientPublicKey;
       req.curve_secretkey = clientPrivateKey;
@@ -68,7 +69,7 @@ describe('socket.zap', function(){
 
   });
 
-  it('should supoort null', function(done){
+  it('should support null', function(done){
     var port = 'tcp://127.0.0.1:12345';
     if (!semver.gte(zmq.version, '4.0.0')) {
       done();
@@ -84,12 +85,12 @@ describe('socket.zap', function(){
     rep.zap_domain = "test";
     rep.mechanism.should.eql(0);
 
-    rep.bind(port, function(){
+    rep.bind(port, function (error) {
+      if (error) throw error;
       req.mechanism.should.eql(0);
       req.connect(port);
       req.send('hello');
       req.on('message', function(msg){
-        console.log('here')
         msg.should.be.an.instanceof(Buffer);
         msg.toString().should.equal('world');
         done();
@@ -97,7 +98,7 @@ describe('socket.zap', function(){
     });
   });
 
-  it('should supoort plain', function(done){
+  it('should support plain', function(done){
     var port = 'tcp://127.0.0.1:12346';
     if (!semver.gte(zmq.version, '4.0.0')) {
       done();
@@ -114,7 +115,8 @@ describe('socket.zap', function(){
     rep.plain_server = 1;
     rep.mechanism.should.eql(1);
 
-    rep.bind(port, function(){
+    rep.bind(port, function (error) {
+      if (error) throw error;
       req.plain_username = "user";
       req.plain_password = "pass";
       req.mechanism.should.eql(1);
@@ -122,7 +124,6 @@ describe('socket.zap', function(){
       req.connect(port);
       req.send('hello');
       req.on('message', function(msg){
-        console.log('here')
         msg.should.be.an.instanceof(Buffer);
         msg.toString().should.equal('world');
         done();

--- a/test/zmq_proxy.push-pull.js
+++ b/test/zmq_proxy.push-pull.js
@@ -65,7 +65,6 @@ describe('proxy.push-pull', function() {
     pull.on('message',function (msg) {
       msg.should.be.an.instanceof(Buffer);
       msg.toString().should.equal('foo');
-      console.log(msg.toString());
     });
 
     capSub.subscribe('');

--- a/test/zmq_proxy.router-dealer.js
+++ b/test/zmq_proxy.router-dealer.js
@@ -68,7 +68,6 @@ describe('proxy.router-dealer', function() {
     req.on('message',function (msg) {
       req.close();
       rep.close();
-      console.log(msg.toString());
     });
 
     rep.on('message', function (msg) {

--- a/test/zmq_proxy.xpub-xsub.js
+++ b/test/zmq_proxy.xpub-xsub.js
@@ -37,8 +37,10 @@ describe('proxy.xpub-xsub', function() {
       done();
     });
 
-    frontend.bind(frontendAddr,function() {
-      backend.bind(backendAddr,function() {
+    frontend.bind(frontendAddr, function (error) {
+      if (error) throw error;
+      backend.bind(backendAddr, function (error) {
+        if (error) throw error;
 
         sub.connect(frontendAddr);
         pub.connect(backendAddr);
@@ -47,7 +49,7 @@ describe('proxy.xpub-xsub', function() {
           pub.send('foo');
         }, 200.0);
 
-        zmq.proxy(frontend,backend);
+        zmq.proxy(frontend, backend);
 
       });
     });
@@ -78,9 +80,6 @@ describe('proxy.xpub-xsub', function() {
 
       msg.should.be.an.instanceof(Buffer);
       msg.toString().should.equal('foo');
-
-      console.log(msg.toString());
-
     });
 
     capSub.subscribe('');
@@ -96,9 +95,12 @@ describe('proxy.xpub-xsub', function() {
       },100.0);
     });
 
-    capture.bind(captureAddr,function() {
-      frontend.bind(frontendAddr,function() {
-        backend.bind(backendAddr,function() {
+    capture.bind(captureAddr, function (error) {
+      if (error) throw error;
+      frontend.bind(frontendAddr, function (error) {
+        if (error) throw error;
+        backend.bind(backendAddr, function (error) {
+          if (error) throw error;
 
           pub.connect(backendAddr);
           sub.connect(frontendAddr);

--- a/test/zmq_proxy.xrep-xreq.js
+++ b/test/zmq_proxy.xrep-xreq.js
@@ -13,8 +13,8 @@ var version = semver.lte(zmq.version, '3.0.0');
 describe('proxy.xrep-xreq', function() {
   it('should proxy req-rep connected to xrep-xreq', function (done) {
     if (!version) {
-      done();
-      return console.warn('Test requires libzmq v2');
+      console.warn('Test requires libzmq v2 (skipping)');
+      return done();
     }
 
     var frontend = zmq.socket('xrep');


### PR DESCRIPTION
This PR almost triples the throughput on the perf test. Buffers are *still* being copied when sent, so there's still room for improvement, but I would say this is a nice start. Review very welcome (cc @kkoopa @reqshark, @gtamas), please be rigorous.

Benchmark before:

```
$ make perf
node perf/local_lat.js tcp://127.0.0.1:5555 1 100000& node perf/remote_lat.js tcp://127.0.0.1:5555 1 100000
started receiving
message size: 1 [B]
roundtrip count: 100000
mean latency: 0.0733293089 [msecs]
overall time: 14 secs and 665861780 nanoseconds

node perf/local_thr.js tcp://127.0.0.1:5556 1 100000& node perf/remote_thr.js tcp://127.0.0.1:5556 1 100000
started receiving
message size: 1 [B]
message count: 100000
mean throughput: 40431 [msg/s]
mean throughput: 0 [Mbit/s]
overall time: 2 secs and 473361003 nanoseconds
```

Benchmark after:

```
$ make perf
node perf/local_lat.js tcp://127.0.0.1:5555 1 100000& node perf/remote_lat.js tcp://127.0.0.1:5555 1 100000
started receiving
message size: 1 [B]
roundtrip count: 100000
mean latency: 0.07873620208 [msecs]
overall time: 15 secs and 747240416 nanoseconds

node perf/local_thr.js tcp://127.0.0.1:5556 1 100000& node perf/remote_thr.js tcp://127.0.0.1:5556 1 100000
started receiving
message size: 1 [B]
message count: 100000
mean throughput: 115861 [msg/s]
mean throughput: 1 [Mbit/s]
overall time: 0 secs and 863099612 nanoseconds
```

Remaining tasks for this PR (post-review, when all is well):

- Remove old code from C++ (unused API replaced by this PR).

Remaining tasks post-merge:

- Code style unification.
- Deprecate ZMQ 2 support
- Release
- Remove ZMQ 2 support
- Deprecate ZMQ 3 support
- Release
- Remove ZMQ 3 support
- Avoid buffer copying when sending messages (GC challenge).
- Find a solution for get/setsockopt to no longer have to find options in Sets in order to apply the right type.