### PR TITLE
Fixes batch isClosed check

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -202,7 +202,7 @@ OutBatch.prototype.append = function (buf, flags, cb) {
     this.cbs.push(cb);
   }
 
-  if ((flags & zmq.SNDMORE) === 0) {
+  if ((flags & zmq.ZMQ_SNDMORE) === 0) {
     this.isClosed = true;
   }
 };

--- a/test/socket.error-callback.js
+++ b/test/socket.error-callback.js
@@ -1,0 +1,26 @@
+
+var zmq = require('..')
+  , should = require('should')
+  , semver = require('semver');
+
+var version = semver.gte(zmq.version, '3.2.0');
+
+describe('socket.error-callback', function(){
+  var sock;
+
+  if (!version) {
+    return console.warn("ZMQ_ROUTER_MANDATORY requires libzmq 3.2.0, skipping test");
+  }
+
+  it('should create a socket and set ZMQ_ROUTER_MANDATORY', function () {
+    sock = zmq.socket('router');
+    sock.setsockopt(zmq.ZMQ_ROUTER_MANDATORY, 1);
+  });
+
+  it('should callback with error when not connected', function (done) {
+    sock.send(['foo', 'bar'], null, function (error) {
+      error.should.be.an.instanceof(Error);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Fixes #512 

A bad flags check was causing batches to not be sized correctly (also making the final send() callback drop outside of the batch). This fixes that.

Performance seems unchanged. If anything, maybe a tiny bit faster.