### PR TITLE
Bump NAN to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "http://github.com/JustinTulloss/zeromq.node.git"
   },
   "dependencies": {
-    "nan": "~2.1.0",
+    "nan": "~2.2.0",
     "bindings": "~1.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This allows compilation on latest node versions

Maybe I should also expand the  testing matrix to include latest node versions?

Closes #514 