### PR TITLE
Bump NAN to 2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "http://github.com/JustinTulloss/zeromq.node.git"
   },
   "dependencies": {
-    "nan": "~2.2.0",
+    "nan": "~2.3.0",
     "bindings": "~1.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This gets rid of deprecation warnings introduced in Node 6.