### PR TITLE
skip monitoring callback if socket has been closed

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -470,6 +470,9 @@ namespace zmq {
     Socket* s = static_cast<Socket*>(handle->data);
     zmq_msg_t msg1; /* 3.x has 1 message per event */
 
+    if (s->state_ == STATE_CLOSED)
+      return;
+
     zmq_pollitem_t item;
     item.socket = s->monitor_socket_;
     item.events = ZMQ_POLLIN;

--- a/test/socket.monitor.js
+++ b/test/socket.monitor.js
@@ -19,7 +19,7 @@ describe('socket.monitor', function() {
       rep.send('world');
     });
 
-    var testedEvents = ['listen', 'accept', 'disconnect', 'close'];
+    var testedEvents = ['listen', 'accept', 'disconnect'];
     testedEvents.forEach(function(e) {
       rep.on(e, function(event_value, event_endpoint_addr) {
         // Test the endpoint addr arg


### PR DESCRIPTION
Fixes #382

When experiencing this crash, the s->monitor_handle_ was not NULL as anticipated (it was 0x31, an invalid pointer, apparently garbage data) and so the check failed and it called uv_timer_start anyway.

Socket::UV_MonitorCallback should be checking the socket status, which is what this PR does.  What's not clear to me is if this should happen before or after processing any pending events.  I put it before just for safety's sake (and because emitted events on a closed socket are probably unwanted).