### PR TITLE
Fixed Socket::Sendv return value bindings.

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -1245,7 +1245,7 @@ namespace zmq {
   NAN_METHOD(Socket::Sendv) {
     Socket* socket = GetSocket(info);
     if (socket->state_ != STATE_READY)
-      return info.GetReturnValue().Set(false);
+      return info.GetReturnValue().Set(0);
 
     int events;
     size_t events_size = sizeof(events);
@@ -1258,7 +1258,7 @@ namespace zmq {
     size_t len = batch->Length();
 
     if (len == 0)
-      return info.GetReturnValue().Set(true);
+      return info.GetReturnValue().Set(1);
 
     if (len % 2 != 0)
       return Nan::ThrowTypeError("Batch length must be even!");
@@ -1278,7 +1278,7 @@ namespace zmq {
           if (readsReady) {
             socket->NotifyReadReady();
           }
-          return info.GetReturnValue().Set(false);
+          return info.GetReturnValue().Set(0);
         }
       }
 
@@ -1330,7 +1330,7 @@ namespace zmq {
       socket->NotifyReadReady();
     }
 
-    return info.GetReturnValue().Set(true);
+    return info.GetReturnValue().Set(1);
   }
 
   // WARNING: the buffer passed here will be kept alive


### PR DESCRIPTION
Fixed issue: The call to the socket.sendv(...) always returned false in my environment, causing a message to be send again and again (up to 32000 times).
It was incorrectly marked as not send, but my server received the first and all following messages and did reply.

Node 6.3.0 on Ubuntu 14.04 32-bit did end up with an undefined behaviour using bool type as a return value.
Returning 0 (False) and 1 (True) does not have these side effects.
Compiled with clang 3.4.