### PR TITLE
Add support for sending Uint8Array objects

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -192,7 +192,7 @@ function OutBatch() {
 }
 
 OutBatch.prototype.append = function (buf, flags, cb) {
-  if (!Buffer.isBuffer(buf)) {
+  if (!Buffer.isBuffer(buf) && !(Uint8Array && buf instanceof Uint8Array)) {
     buf = new Buffer(String(buf), 'utf8');
   }
 


### PR DESCRIPTION
I added support for sending `Uint8Array` objects over a zmq socket. The problem was that zmq was wrapping the `Uint8Array` object in a `Buffer` before sending the object out.