### PR TITLE
Bump dependencies to fix deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
     "url": "http://github.com/JustinTulloss/zeromq.node.git"
   },
   "dependencies": {
-    "nan": "~2.3.0",
-    "bindings": "~1.2.1"
+    "bindings": "~1.2.1",
+    "nan": "^2.4.0"
   },
   "devDependencies": {
-    "should": "2.1.x",
-    "semver": "~4.1.1",
-    "mocha": "~1.13.0"
+    "mocha": "^3.1.0",
+    "semver": "^5.3.0",
+    "should": "^11.1.0"
   },
   "engines": {
     "node": ">=0.8"


### PR DESCRIPTION
This removes the deprecation warning:
`child_process: customFds option is deprecated, use stdio instead.`