### PR TITLE
Reduce mocha timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "node": ">=0.8"
   },
   "scripts": {
-    "test": "mocha --expose-gc --slow 2000 --timeout 600000"
+    "test": "mocha --expose-gc --slow 300"
   },
   "keywords": ["zeromq", "zmq", "0mq", "ømq", "libzmq", "native", "binding", "addon"],
   "license": "MIT",


### PR DESCRIPTION
A 10min timeout is far to long.
Since we are using `travis_retry` when running the tests a short timeout won't cause accidental failures.