### PR TITLE
Fix monitor test

### DIFF
--- a/test/socket.monitor.js
+++ b/test/socket.monitor.js
@@ -10,8 +10,7 @@ describe('socket.monitor', function() {
 
   it('should be able to monitor the socket', function(done) {
     var rep = zmq.socket('rep')
-      , req = zmq.socket('req')
-      , events = [];
+      , req = zmq.socket('req');
 
     rep.on('message', function(msg){
       msg.should.be.an.instanceof(Buffer);
@@ -25,14 +24,10 @@ describe('socket.monitor', function() {
         // Test the endpoint addr arg
         event_endpoint_addr.toString().should.equal('tcp://127.0.0.1:5423');
 
-        // If this is a disconnect event we can now close the rep socket
-        if (e === 'disconnect') {
-          rep.close();
-        }
-
         testedEvents.pop();
         if (testedEvents.length === 0) {
           rep.unmonitor();
+          rep.close();
           done();
         }
       });


### PR DESCRIPTION
As mentioned in #561, on OS X with homebrewed zeromq the tests are failing quite often.

@ronkorving I don't know if this is a bug that should be fixed properly. If so this PR should provide a hint on what's failing.

<details>
<summary>The full error message from master is here (expand me):</summary>
```
  39 passing (21s)
  15 failing

  1) socket.monitor should use default interval and numOfEvents:
     Error: timeout of 2000ms exceeded
      at Timeout.<anonymous> (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runnable.js:165:14)
      at tryOnTimeout (timers.js:232:11)
      at Timer.listOnTimeout (timers.js:202:5)

  2) socket.monitor should read multiple events on monitor interval:
     Error: timeout of 2000ms exceeded
      at Timeout.<anonymous> (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runnable.js:165:14)
      at tryOnTimeout (timers.js:232:11)
      at Timer.listOnTimeout (timers.js:202:5)

  3) socket.router should handle router <-> dealer message bursts:
     Error: timeout of 2000ms exceeded
      at Timeout.<anonymous> (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runnable.js:165:14)
      at tryOnTimeout (timers.js:232:11)
      at Timer.listOnTimeout (timers.js:202:5)

  4) socket.unbind should be able to unbind:
     Error: timeout of 2000ms exceeded
      at Timeout.<anonymous> (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runnable.js:165:14)
      at tryOnTimeout (timers.js:232:11)
      at Timer.listOnTimeout (timers.js:202:5)

  5) socket.xpub-xsub should support pub-sub tracing and filtering:
     Error: timeout of 2000ms exceeded
      at Timeout.<anonymous> (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runnable.js:165:14)
      at tryOnTimeout (timers.js:232:11)
      at Timer.listOnTimeout (timers.js:202:5)

  6) socket.zap should support curve:
     Error: timeout of 2000ms exceeded
      at Timeout.<anonymous> (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runnable.js:165:14)
      at tryOnTimeout (timers.js:232:11)
      at Timer.listOnTimeout (timers.js:202:5)

  7) socket.zap should support null:
     Uncaught Error: Address already in use
      at Error (native)

  8) socket.zap should support plain:
     Error: timeout of 2000ms exceeded
      at Timeout.<anonymous> (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runnable.js:165:14)
      at tryOnTimeout (timers.js:232:11)
      at Timer.listOnTimeout (timers.js:202:5)

  9) proxy.push-pull should proxy push-pull connected to pull-push:
     Error: timeout of 2000ms exceeded
      at Timeout.<anonymous> (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runnable.js:165:14)
      at tryOnTimeout (timers.js:232:11)
      at Timer.listOnTimeout (timers.js:202:5)

  10) proxy.push-pull should proxy pull-push connected to push-pull with capture:
     Error: Address already in use
      at Error (native)
      at Socket.bindSync (/Users/lukasgeiger/code/zeromq.node/lib/index.js:442:13)
      at Context.<anonymous> (/Users/lukasgeiger/code/zeromq.node/test/zmq_proxy.push-pull.js:57:14)
      at Test.Runnable.run (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runnable.js:194:15)
      at Runner.runTest (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runner.js:358:10)
      at /Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runner.js:404:12
      at next (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runner.js:284:14)
      at /Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runner.js:293:7
      at next (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runner.js:237:23)
      at Immediate.<anonymous> (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runner.js:261:5)
      at runCallback (timers.js:574:20)
      at tryOnImmediate (timers.js:554:5)
      at processImmediate [as _immediateCallback] (timers.js:533:5)

  11) proxy.router-dealer should proxy req-rep connected over router-dealer:
     Error: timeout of 2000ms exceeded
      at Timeout.<anonymous> (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runnable.js:165:14)
      at tryOnTimeout (timers.js:232:11)
      at Timer.listOnTimeout (timers.js:202:5)

  12) proxy.router-dealer should proxy rep-req connections with capture:
     Error: Address already in use
      at Error (native)
      at Socket.bindSync (/Users/lukasgeiger/code/zeromq.node/lib/index.js:442:13)
      at Context.<anonymous> (/Users/lukasgeiger/code/zeromq.node/test/zmq_proxy.router-dealer.js:59:14)
      at Test.Runnable.run (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runnable.js:194:15)
      at Runner.runTest (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runner.js:358:10)
      at /Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runner.js:404:12
      at next (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runner.js:284:14)
      at /Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runner.js:293:7
      at next (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runner.js:237:23)
      at Immediate.<anonymous> (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runner.js:261:5)
      at runCallback (timers.js:574:20)
      at tryOnImmediate (timers.js:554:5)
      at processImmediate [as _immediateCallback] (timers.js:533:5)

  13) proxy.xpub-xsub should proxy pub-sub connected to xpub-xsub:
     Error: timeout of 2000ms exceeded
      at Timeout.<anonymous> (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runnable.js:165:14)
      at tryOnTimeout (timers.js:232:11)
      at Timer.listOnTimeout (timers.js:202:5)

  14) proxy.xpub-xsub should proxy connections with capture:
     Uncaught Error: Address already in use
      at Error (native)

  15) proxy.xpub-xsub should throw an error if the order is wrong:
     Error: Address already in use
      at Error (native)
      at Socket.bindSync (/Users/lukasgeiger/code/zeromq.node/lib/index.js:442:13)
      at Context.<anonymous> (/Users/lukasgeiger/code/zeromq.node/test/zmq_proxy.xpub-xsub.js:131:14)
      at Test.Runnable.run (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runnable.js:194:15)
      at Runner.runTest (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runner.js:358:10)
      at /Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runner.js:404:12
      at next (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runner.js:284:14)
      at /Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runner.js:293:7
      at next (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runner.js:237:23)
      at Immediate.<anonymous> (/Users/lukasgeiger/code/zeromq.node/node_modules/mocha/lib/runner.js:261:5)
      at runCallback (timers.js:574:20)
      at tryOnImmediate (timers.js:554:5)
      at processImmediate [as _immediateCallback] (timers.js:533:5)
```
</details>