### PR TITLE
Added ZMQ_ROUTER_HANDOVER socket option

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -1536,6 +1536,7 @@ namespace zmq {
     opts_int.insert(51); //ZMQ_PROBE_ROUTER
     opts_binary.insert(55); // ZMQ_ZAP_DOMAIN
     opts_int.insert(66); //ZMQ_HANDSHAKE_IVL
+    opts_int.insert(56); // ZMQ_ROUTER_HANDOVER
     #endif
 
     NODE_DEFINE_CONSTANT(target, ZMQ_CAN_DISCONNECT);

--- a/lib/index.js
+++ b/lib/index.js
@@ -95,6 +95,7 @@ var longOptions = {
   , ZMQ_ZAP_DOMAIN: 55
   , ZMQ_IO_THREADS: 1
   , ZMQ_MAX_SOCKETS: 2
+  , ZMQ_ROUTER_HANDOVER: 56
 };
 
 Object.keys(longOptions).forEach(function(name){

--- a/windows/include/zmq.h
+++ b/windows/include/zmq.h
@@ -288,6 +288,8 @@ ZMQ_EXPORT int zmq_msg_set (zmq_msg_t *msg, int option, int optval);
 #define ZMQ_REQ_RELAXED 53
 #define ZMQ_CONFLATE 54
 #define ZMQ_ZAP_DOMAIN 55
+#define ZMQ_ROUTER_HANDOVER 56
+
 
 /*  Message options                                                           */
 #define ZMQ_MORE 1


### PR DESCRIPTION
This option is introduced in 4.1 and is very useful for ROUTER sockets.