### PR TITLE
Added optional callback for connect()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -493,13 +493,24 @@ Socket.prototype.unbindSync = function(addr) {
  * Connect to `addr`.
  *
  * @param {String} addr
+ * @param {Function} cb
  * @return {Socket} for chaining
  * @api public
  */
 
-Socket.prototype.connect = function(addr) {
-  this._zmq.connect(addr);
-  return this;
+Socket.prototype.connect = function(addr, cb) {
+  if (!cb) {
+    this._zmq.connect(addr);
+    return this;
+  }
+
+  try {
+    this._zmq.connect(addr);
+    return cb && cb();
+  }
+  catch (ex) {
+    return cb && cb(ex);
+  }
 };
 
 /**


### PR DESCRIPTION
Although `connect()` is a sync operation, it kind of pairs with `bind()`.  Therefore it's nice to be able to pass a callback to either if desired, to do something once the operation is complete.  This adds an optional callback to `connect()`, leaving the current functionality in place if no callback is provided.  Partially deals with issue #298.