### PR TITLE
Fix socket stops receiving messages (#558)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -623,19 +623,25 @@ Socket.prototype.send = function(msg, flags, cb) {
   return this;
 };
 
+Socket.prototype._emitMessages = function (messages) {
+  if (messages.length === 1) {
+    // hot path
+    this.emit('message', messages[0]);
+  } else {
+    this.emit.apply(this, ['message'].concat(messages));
+  }
+}
 
 Socket.prototype._flushRead = function () {
-  var message = this._zmq.readv(); // can throw
-  if (!message) {
-    return false;
-  }
-
-  // Handle received message immediately to prevent memory leak in driver
-  if (message.length === 1) {
-    // hot path
-    this.emit('message', message[0]);
-  } else {
-    this.emit.apply(this, ['message'].concat(message));
+  try {
+    var messages = this._zmq.readv(); // can throw
+    if (!messages) {
+      return false;
+    }
+    // Handle received message immediately to prevent memory leak in driver
+    this._emitMessages(messages)
+  } catch (error) {
+    this.emit('error', error); // can throw
   }
   return true;
 };
@@ -669,17 +675,7 @@ Socket.prototype._flushReads = function() {
 
   this._isFlushingReads = true;
 
-  var received;
-
-  do {
-    try {
-      received = this._flushRead();
-    } catch (error) {
-      this._isFlushingReads = false;
-      this.emit('error', error); // can throw
-      return;
-    }
-  } while (received);
+  while (this._flushRead());
 
   this._isFlushingReads = false;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -623,23 +623,23 @@ Socket.prototype.send = function(msg, flags, cb) {
   return this;
 };
 
-Socket.prototype._emitMessages = function (messages) {
-  if (messages.length === 1) {
+Socket.prototype._emitMessage = function (message) {
+  if (message.length === 1) {
     // hot path
-    this.emit('message', messages[0]);
+    this.emit('message', message[0]);
   } else {
-    this.emit.apply(this, ['message'].concat(messages));
+    this.emit.apply(this, ['message'].concat(message));
   }
 }
 
 Socket.prototype._flushRead = function () {
   try {
-    var messages = this._zmq.readv(); // can throw
-    if (!messages) {
+    var message = this._zmq.readv(); // can throw
+    if (!message) {
       return false;
     }
     // Handle received message immediately to prevent memory leak in driver
-    this._emitMessages(messages)
+    this._emitMessage(message)
   } catch (error) {
     this.emit('error', error); // can throw
   }


### PR DESCRIPTION
If error is thrown in message event handler and error event handler is attached to socket, `_flushRead` is called until no more messages are read.
