### PR TITLE
if an event is an error, pass the exception object

### DIFF
--- a/binding.cc
+++ b/binding.cc
@@ -441,12 +441,22 @@ namespace zmq {
       return;
     }
 
-    Local<Value> argv[3];
+    Local<Value> argv[4];
     argv[0] = Nan::New<Integer>(event_id);
     argv[1] = Nan::New<Integer>(event_value);
     argv[2] = Nan::New<String>(event_endpoint).ToLocalChecked();
+    switch (event_id) {
+      case ZMQ_EVENT_BIND_FAILED:
+      case ZMQ_EVENT_ACCEPT_FAILED:
+      case ZMQ_EVENT_CLOSE_FAILED:
+        argv[3] = ExceptionFromError();
+        break;
+      default:
+        argv[3] = Nan::Undefined();
+        break;
+    }
 
-    Nan::MakeCallback(this->handle(), callback_v.As<Function>(), 3, argv);
+    Nan::MakeCallback(this->handle(), callback_v.As<Function>(), 4, argv);
   }
 
   void

--- a/lib/index.js
+++ b/lib/index.js
@@ -530,8 +530,8 @@ Socket.prototype.monitor = function(interval, numOfEvents) {
   if (zmq.ZMQ_CAN_MONITOR) {
     var self = this;
 
-    self._zmq.onMonitorEvent = function(event_id, event_value, event_endpoint_addr) {
-      self.emit(events[event_id], event_value, event_endpoint_addr);
+    self._zmq.onMonitorEvent = function(event_id, event_value, event_endpoint_addr, ex) {
+      self.emit(events[event_id], event_value, event_endpoint_addr, ex);
     }
 
     self._zmq.onMonitorError = function(error) {

--- a/test/socket.monitor.js
+++ b/test/socket.monitor.js
@@ -48,6 +48,17 @@ describe('socket.monitor', function() {
         msg.toString().should.equal('world');
         req.close();
       });
+
+      // Test that bind errors pass an Error both to the callback
+      // and to the monitor event
+      var doubleRep = zmq.socket('rep');
+      doubleRep.monitor();
+      doubleRep.on('bind_error', function (errno, bindAddr, ex) {
+        (ex instanceof Error).should.equal(true);
+      });
+      doubleRep.bind('tcp://127.0.0.1:5423', function (error) {
+        (error instanceof Error).should.equal(true);
+      });
     });
   });
 


### PR DESCRIPTION
Events emitted due to socket monitoring may represent an error, and currently only return the numeric errno.  The binding has a method to translate these to the string that `zmq_strerror` provides but this is not exposed.  Add one, and use it to provide the exception it generates to the callback.

I don't love the function signature to the event callback with this change, but I wrote it that way to be backwards compatible.  If you have a better suggestion, I'm open to ideas.