### PR TITLE
Made the package compile in termux on android

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -70,6 +70,11 @@
             '<!(pkg-config libzmq --libs 2>/dev/null || echo "")',
           ],
         }],
+        ['OS=="android"', {
+          'libraries': ['-lzmq'],
+          'cflags': ['-fPIC'],
+          'cflags_cc': ['-fPIC'],
+        }],
       ]
     }
   ]


### PR DESCRIPTION
To compile the package in the termux app on android you have to compile the sources with the compiler flag "-fPIC". I added this in an special condition branch. The compiled package is working properly within the following constellation jupyter-nodejs -> zeromq.node.