### PR TITLE
Update package.json to use the latest nan (2.10.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "bindings": "~1.2.1",
-    "nan": "^2.4.0"
+    "nan": "^2.10.0"
   },
   "devDependencies": {
     "mocha": "^3.1.0",


### PR DESCRIPTION
Upon using the old nan, installation (macOS 10.13.6) failed using node 10.x due to "error: no member named 'ForceSet' in 'v8::Object' ". With the newest nan (2.10.0) specified, everything works perfectly. This is my first PR, so is there anything more I should add?